### PR TITLE
Move back AttributeValue and Status from data to the main package.

### DIFF
--- a/api/src/main/java/openconsensus/trace/AttributeValue.java
+++ b/api/src/main/java/openconsensus/trace/AttributeValue.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package openconsensus.trace.data;
+package openconsensus.trace;
 
 import com.google.auto.value.AutoValue;
 import javax.annotation.concurrent.Immutable;

--- a/api/src/main/java/openconsensus/trace/BlankSpan.java
+++ b/api/src/main/java/openconsensus/trace/BlankSpan.java
@@ -19,10 +19,8 @@ package openconsensus.trace;
 import java.util.Map;
 import javax.annotation.concurrent.Immutable;
 import openconsensus.internal.Utils;
-import openconsensus.trace.data.AttributeValue;
 import openconsensus.trace.data.Event;
 import openconsensus.trace.data.MessageEvent;
-import openconsensus.trace.data.Status;
 
 /**
  * The {@code BlankSpan} is a singleton class, which is the default {@link Span} that is used when

--- a/api/src/main/java/openconsensus/trace/Link.java
+++ b/api/src/main/java/openconsensus/trace/Link.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.concurrent.Immutable;
-import openconsensus.trace.data.AttributeValue;
 
 /**
  * A link to a {@link Span} from a different trace.

--- a/api/src/main/java/openconsensus/trace/Span.java
+++ b/api/src/main/java/openconsensus/trace/Span.java
@@ -17,10 +17,8 @@
 package openconsensus.trace;
 
 import java.util.Map;
-import openconsensus.trace.data.AttributeValue;
 import openconsensus.trace.data.Event;
 import openconsensus.trace.data.MessageEvent;
-import openconsensus.trace.data.Status;
 
 /**
  * An abstract class that represents a span. It has an associated {@link SpanContext}.

--- a/api/src/main/java/openconsensus/trace/SpanBuilder.java
+++ b/api/src/main/java/openconsensus/trace/SpanBuilder.java
@@ -18,7 +18,6 @@ package openconsensus.trace;
 
 import java.util.List;
 import java.util.concurrent.Callable;
-import openconsensus.trace.data.Status;
 
 /**
  * {@link SpanBuilder} is used to construct {@link Span} instances which define arbitrary scopes of

--- a/api/src/main/java/openconsensus/trace/Status.java
+++ b/api/src/main/java/openconsensus/trace/Status.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package openconsensus.trace.data;
+package openconsensus.trace;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,7 +24,6 @@ import java.util.TreeMap;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import openconsensus.internal.Utils;
-import openconsensus.trace.Span;
 
 /**
  * Defines the status of a {@link Span} by providing a standard {@link CanonicalCode} in conjunction

--- a/api/src/main/java/openconsensus/trace/Tracer.java
+++ b/api/src/main/java/openconsensus/trace/Tracer.java
@@ -21,7 +21,6 @@ import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 import openconsensus.context.Scope;
 import openconsensus.trace.data.SpanData;
-import openconsensus.trace.data.Status;
 import openconsensus.trace.propagation.BinaryFormat;
 import openconsensus.trace.propagation.TextFormat;
 

--- a/api/src/main/java/openconsensus/trace/data/Event.java
+++ b/api/src/main/java/openconsensus/trace/data/Event.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.concurrent.Immutable;
 import openconsensus.internal.Utils;
+import openconsensus.trace.AttributeValue;
 
 /**
  * A text annotation with a set of attributes.

--- a/api/src/main/java/openconsensus/trace/data/SpanData.java
+++ b/api/src/main/java/openconsensus/trace/data/SpanData.java
@@ -26,11 +26,13 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import openconsensus.common.Timestamp;
 import openconsensus.internal.Utils;
+import openconsensus.trace.AttributeValue;
 import openconsensus.trace.Link;
 import openconsensus.trace.Span;
 import openconsensus.trace.Span.Kind;
 import openconsensus.trace.SpanContext;
 import openconsensus.trace.SpanId;
+import openconsensus.trace.Status;
 
 /**
  * Immutable representation of all data collected by the {@link Span} class.

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
@@ -24,9 +24,9 @@ import io.opentracing.tag.Tag;
 import io.opentracing.tag.Tags;
 import java.util.ArrayList;
 import java.util.List;
+import openconsensus.trace.AttributeValue;
 import openconsensus.trace.Span.Kind;
-import openconsensus.trace.data.AttributeValue;
-import openconsensus.trace.data.Status;
+import openconsensus.trace.Status;
 
 @SuppressWarnings("deprecation")
 final class SpanBuilderShim implements SpanBuilder {

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
@@ -22,8 +22,8 @@ import io.opentracing.log.Fields;
 import io.opentracing.tag.Tag;
 import java.util.HashMap;
 import java.util.Map;
-import openconsensus.trace.data.AttributeValue;
-import openconsensus.trace.data.Status;
+import openconsensus.trace.AttributeValue;
+import openconsensus.trace.Status;
 
 final class SpanShim implements Span {
   private static final String DEFAULT_EVENT_NAME = "log";


### PR DESCRIPTION
The main reason is because we have circular dependencies between packages: main -> data and data -> main 