### PR TITLE
fix javadoc issues

### DIFF
--- a/api/src/main/java/openconsensus/stats/Measure.java
+++ b/api/src/main/java/openconsensus/stats/Measure.java
@@ -42,7 +42,6 @@ public abstract class Measure {
    * <p>Suggested format for name: {@code <web_host>/<path>}.
    *
    * @return the name of this measure.
-   *
    * @since 0.1.0
    */
   public abstract String getName();

--- a/api/src/main/java/openconsensus/stats/Measure.java
+++ b/api/src/main/java/openconsensus/stats/Measure.java
@@ -41,6 +41,8 @@ public abstract class Measure {
    *
    * <p>Suggested format for name: {@code <web_host>/<path>}.
    *
+   * @return the name of this measure.
+   *
    * @since 0.1.0
    */
   public abstract String getName();
@@ -48,6 +50,7 @@ public abstract class Measure {
   /**
    * Detailed description of the measure, used in documentation.
    *
+   * @return the description of this measure.
    * @since 0.1.0
    */
   public abstract String getDescription();
@@ -66,6 +69,7 @@ public abstract class Measure {
    * <p>For example, string “MBy{transmitted}/ms” stands for megabytes per milliseconds, and the
    * annotation transmitted inside {} is just a comment of the unit.
    *
+   * @return the unit of this measure.
    * @since 0.1.0
    */
   public abstract String getUnit();

--- a/api/src/main/java/openconsensus/stats/Measurement.java
+++ b/api/src/main/java/openconsensus/stats/Measurement.java
@@ -31,6 +31,7 @@ public abstract class Measurement {
   /**
    * Extracts the measured {@link Measure}.
    *
+   * @return the {@link Measure} if this measurement.
    * @since 0.1.0
    */
   public abstract Measure getMeasure();

--- a/api/src/main/java/openconsensus/tags/TagMap.java
+++ b/api/src/main/java/openconsensus/tags/TagMap.java
@@ -42,6 +42,7 @@ public abstract class TagMap {
   /**
    * Returns the {@code TagValue} associated with the given {@code TagKey}.
    *
+   * @param tagKey tag key to return the value for.
    * @return the {@code TagValue} associated with the given {@code TagKey}, or {@code null} if no
    *     {@code Tag} with the given {@code tagKey} is in this {@code TagMap}.
    */

--- a/api/src/main/java/openconsensus/trace/SpanData.java
+++ b/api/src/main/java/openconsensus/trace/SpanData.java
@@ -45,6 +45,7 @@ public abstract class SpanData {
    * @param context the {@code SpanContext} of the {@code Span}.
    * @param parentSpanId the parent {@code SpanId} of the {@code Span}. {@code null} if the {@code
    *     Span} is a root.
+   * @param resource the resource this span was executed on.
    * @param name the name of the {@code Span}.
    * @param kind the kind of the {@code Span}.
    * @param startTimestamp the start {@code Timestamp} of the {@code Span}.


### PR DESCRIPTION
I'm not sure what to do with thise:

```
/Users/sergeykanzhelev/src/openconsensus/api/src/main/java/openconsensus/trace/SpanBuilder.java:239: warning: {@code} within <code>
   * {@code Callable<MyResult>} newCallable = tracer.withSpan(span, myCallable);
     ^
/Users/sergeykanzhelev/src/openconsensus/api/src/main/java/openconsensus/trace/Tracer.java:227: warning: {@code} within <code>
   *     executor.execute(tracer.withSpan(span, {@code new Callable<MyResult>()} {
                                                ^
/Users/sergeykanzhelev/src/openconsensus/api/src/main/java/openconsensus/trace/Tracer.java:248: warning: {@code} within <code>
   *     executor.execute(Context.wrap(tracer.withSpan(span, {@code new Callable<MyResult>()} {
```