### PR TITLE
Add tests on APIs.

### DIFF
--- a/api/src/main/java/openconsensus/stats/Measure.java
+++ b/api/src/main/java/openconsensus/stats/Measure.java
@@ -29,7 +29,7 @@ import openconsensus.internal.Utils;
 @Immutable
 @AutoValue
 public abstract class Measure {
-  private static final int NAME_MAX_LENGTH = 255;
+  /* VisibleForTesting */ static final int NAME_MAX_LENGTH = 255;
   private static final String ERROR_MESSAGE_INVALID_NAME =
       "Name should be a ASCII string with a length no greater than "
           + NAME_MAX_LENGTH

--- a/api/src/test/java/openconsensus/internal/StringUtilsTest.java
+++ b/api/src/test/java/openconsensus/internal/StringUtilsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link StringUtils}. */
+@RunWith(JUnit4.class)
+public final class StringUtilsTest {
+
+  @Test
+  public void isPrintableString() {
+    assertTrue(StringUtils.isPrintableString("abcd"));
+    assertFalse(StringUtils.isPrintableString("\2ab\3cd"));
+  }
+}

--- a/api/src/test/java/openconsensus/internal/UtilsTest.java
+++ b/api/src/test/java/openconsensus/internal/UtilsTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Date;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Utils}. */
+@RunWith(JUnit4.class)
+public final class UtilsTest {
+  private static final String TEST_MESSAGE = "test message";
+  private static final String TEST_MESSAGE_TEMPLATE = "I ate %s eggs.";
+  private static final int TEST_MESSAGE_VALUE = 2;
+  private static final String FORMATTED_SIMPLE_TEST_MESSAGE = "I ate 2 eggs.";
+  private static final String FORMATTED_COMPLEX_TEST_MESSAGE = "I ate 2 eggs. [2]";
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void checkArgument() {
+    Utils.checkArgument(true, TEST_MESSAGE);
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(TEST_MESSAGE);
+    Utils.checkArgument(false, TEST_MESSAGE);
+  }
+
+  @Test
+  public void checkArgument_NullErrorMessage() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("null");
+    Utils.checkArgument(false, null);
+  }
+
+  @Test
+  public void checkArgument_WithSimpleFormat() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(FORMATTED_SIMPLE_TEST_MESSAGE);
+    Utils.checkArgument(false, TEST_MESSAGE_TEMPLATE, TEST_MESSAGE_VALUE);
+  }
+
+  @Test
+  public void checkArgument_WithComplexFormat() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(FORMATTED_COMPLEX_TEST_MESSAGE);
+    Utils.checkArgument(false, TEST_MESSAGE_TEMPLATE, TEST_MESSAGE_VALUE, TEST_MESSAGE_VALUE);
+  }
+
+  @Test
+  public void checkState() {
+    Utils.checkNotNull(true, TEST_MESSAGE);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage(TEST_MESSAGE);
+    Utils.checkState(false, TEST_MESSAGE);
+  }
+
+  @Test
+  public void checkState_NullErrorMessage() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("null");
+    Utils.checkState(false, null);
+  }
+
+  @Test
+  public void checkNotNull() {
+    Utils.checkNotNull(new Object(), TEST_MESSAGE);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage(TEST_MESSAGE);
+    Utils.checkNotNull(null, TEST_MESSAGE);
+  }
+
+  @Test
+  public void checkNotNull_NullErrorMessage() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("null");
+    Utils.checkNotNull(null, null);
+  }
+
+  @Test
+  public void checkIndex_Valid() {
+    Utils.checkIndex(1, 2);
+  }
+
+  @Test
+  public void checkIndex_NegativeSize() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Negative size: -1");
+    Utils.checkIndex(0, -1);
+  }
+
+  @Test
+  public void checkIndex_NegativeIndex() {
+    thrown.expect(IndexOutOfBoundsException.class);
+    thrown.expectMessage("Index out of bounds: size=10, index=-2");
+    Utils.checkIndex(-2, 10);
+  }
+
+  @Test
+  public void checkIndex_IndexEqualToSize() {
+    thrown.expect(IndexOutOfBoundsException.class);
+    thrown.expectMessage("Index out of bounds: size=5, index=5");
+    Utils.checkIndex(5, 5);
+  }
+
+  @Test
+  public void checkIndex_IndexGreaterThanSize() {
+    thrown.expect(IndexOutOfBoundsException.class);
+    thrown.expectMessage("Index out of bounds: size=10, index=11");
+    Utils.checkIndex(11, 10);
+  }
+
+  @Test
+  public void equalsObjects_Equal() {
+    assertTrue(Utils.equalsObjects(null, null));
+    assertTrue(Utils.equalsObjects(new Date(1L), new Date(1L)));
+  }
+
+  @Test
+  public void equalsObjects_Unequal() {
+    assertFalse(Utils.equalsObjects(null, new Object()));
+    assertFalse(Utils.equalsObjects(new Object(), null));
+    assertFalse(Utils.equalsObjects(new Object(), new Object()));
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/DerivedDoubleCumulativeTest.java
+++ b/api/src/test/java/openconsensus/metrics/DerivedDoubleCumulativeTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import openconsensus.common.ToDoubleFunction;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DerivedDoubleCumulative}. */
+@RunWith(JUnit4.class)
+public class DerivedDoubleCumulativeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final MetricRegistry metricRegistry = NoopMetrics.newNoopMetricRegistry();
+  private final DerivedDoubleCumulative derivedDoubleCumulative =
+      metricRegistry.addDerivedDoubleCumulative(
+          NAME,
+          MetricOptions.builder()
+              .setDescription(DESCRIPTION)
+              .setLabelKeys(LABEL_KEY)
+              .setUnit(UNIT)
+              .build());
+  private static final ToDoubleFunction<Object> doubleFunction =
+      new ToDoubleFunction<Object>() {
+        @Override
+        public double applyAsDouble(Object value) {
+          return 5.0;
+        }
+      };
+
+  @Test
+  public void noopCreateTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleCumulative.createTimeSeries(null, null, doubleFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    derivedDoubleCumulative.createTimeSeries(labelValues, null, doubleFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithInvalidLabelSize() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    derivedDoubleCumulative.createTimeSeries(EMPTY_LABEL_VALUES, null, doubleFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithNullFunction() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("function");
+    derivedDoubleCumulative.createTimeSeries(LABEL_VALUES, null, null);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleCumulative.removeTimeSeries(null);
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/DerivedDoubleGaugeTest.java
+++ b/api/src/test/java/openconsensus/metrics/DerivedDoubleGaugeTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import openconsensus.common.ToDoubleFunction;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DerivedDoubleGauge}. */
+@RunWith(JUnit4.class)
+public class DerivedDoubleGaugeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final MetricRegistry metricRegistry = NoopMetrics.newNoopMetricRegistry();
+  private final DerivedDoubleGauge derivedDoubleGauge =
+      metricRegistry.addDerivedDoubleGauge(
+          NAME,
+          MetricOptions.builder()
+              .setDescription(DESCRIPTION)
+              .setLabelKeys(LABEL_KEY)
+              .setUnit(UNIT)
+              .build());
+  private static final ToDoubleFunction<Object> doubleFunction =
+      new ToDoubleFunction<Object>() {
+        @Override
+        public double applyAsDouble(Object value) {
+          return 5.0;
+        }
+      };
+
+  @Test
+  public void noopCreateTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleGauge.createTimeSeries(null, null, doubleFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    derivedDoubleGauge.createTimeSeries(labelValues, null, doubleFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithInvalidLabelSize() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    derivedDoubleGauge.createTimeSeries(EMPTY_LABEL_VALUES, null, doubleFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithNullFunction() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("function");
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, null, null);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleGauge.removeTimeSeries(null);
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/DerivedLongGaugeTest.java
+++ b/api/src/test/java/openconsensus/metrics/DerivedLongGaugeTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import openconsensus.common.ToLongFunction;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DerivedLongGauge}. */
+@RunWith(JUnit4.class)
+public class DerivedLongGaugeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final MetricRegistry metricRegistry = NoopMetrics.newNoopMetricRegistry();
+  private final DerivedLongGauge derivedLongGauge =
+      metricRegistry.addDerivedLongGauge(
+          NAME,
+          MetricOptions.builder()
+              .setDescription(DESCRIPTION)
+              .setLabelKeys(LABEL_KEY)
+              .setUnit(UNIT)
+              .build());
+  private static final ToLongFunction<Object> longFunction =
+      new ToLongFunction<Object>() {
+        @Override
+        public long applyAsLong(Object value) {
+          return 5;
+        }
+      };
+
+  @Test
+  public void noopCreateTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedLongGauge.createTimeSeries(null, null, longFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    derivedLongGauge.createTimeSeries(labelValues, null, longFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithInvalidLabelSize() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    derivedLongGauge.createTimeSeries(EMPTY_LABEL_VALUES, null, longFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithNullFunction() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("function");
+    derivedLongGauge.createTimeSeries(LABEL_VALUES, null, null);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedLongGauge.removeTimeSeries(null);
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/DoubleCumulativeTest.java
+++ b/api/src/test/java/openconsensus/metrics/DoubleCumulativeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DoubleCumulative}. */
+@RunWith(JUnit4.class)
+public class DoubleCumulativeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelKey> EMPTY_LABEL_KEYS = new ArrayList<LabelKey>();
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final MetricRegistry metricRegistry = NoopMetrics.newNoopMetricRegistry();
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
+    DoubleCumulative doubleCumulative =
+        metricRegistry.addDoubleCumulative(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    doubleCumulative.getOrCreateTimeSeries(null);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    DoubleCumulative doubleCumulative =
+        metricRegistry.addDoubleCumulative(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    doubleCumulative.getOrCreateTimeSeries(labelValues);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
+    DoubleCumulative doubleCumulative =
+        metricRegistry.addDoubleCumulative(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    doubleCumulative.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    DoubleCumulative doubleCumulative =
+        metricRegistry.addDoubleCumulative(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    doubleCumulative.removeTimeSeries(null);
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/DoubleGaugeTest.java
+++ b/api/src/test/java/openconsensus/metrics/DoubleGaugeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DoubleGauge}. */
+@RunWith(JUnit4.class)
+public class DoubleGaugeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelKey> EMPTY_LABEL_KEYS = new ArrayList<LabelKey>();
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final MetricRegistry metricRegistry = NoopMetrics.newNoopMetricRegistry();
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
+    DoubleGauge doubleGauge =
+        metricRegistry.addDoubleGauge(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    doubleGauge.getOrCreateTimeSeries(null);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    DoubleGauge doubleGauge =
+        metricRegistry.addDoubleGauge(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    doubleGauge.getOrCreateTimeSeries(labelValues);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
+    DoubleGauge doubleGauge =
+        metricRegistry.addDoubleGauge(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    doubleGauge.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    DoubleGauge doubleGauge =
+        metricRegistry.addDoubleGauge(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    doubleGauge.removeTimeSeries(null);
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/LabelKeyTest.java
+++ b/api/src/test/java/openconsensus/metrics/LabelKeyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link LabelKey}. */
+@RunWith(JUnit4.class)
+public class LabelKeyTest {
+
+  private static final LabelKey KEY = LabelKey.create("key", "description");
+
+  @Test
+  public void testGetKey() {
+    assertThat(KEY.getKey()).isEqualTo("key");
+  }
+
+  @Test
+  public void testGetDescription() {
+    assertThat(KEY.getDescription()).isEqualTo("description");
+  }
+
+  @Test
+  public void create_NoLengthConstraint() {
+    // We have a length constraint of 256-characters for TagKey. That constraint doesn't apply to
+    // LabelKey.
+    char[] chars = new char[300];
+    Arrays.fill(chars, 'k');
+    String key = new String(chars);
+    assertThat(LabelKey.create(key, "").getKey()).isEqualTo(key);
+  }
+
+  @Test
+  public void create_WithUnprintableChars() {
+    String key = "\2ab\3cd";
+    String description = "\4ef\5gh";
+    LabelKey labelKey = LabelKey.create(key, description);
+    assertThat(labelKey.getKey()).isEqualTo(key);
+    assertThat(labelKey.getDescription()).isEqualTo(description);
+  }
+
+  @Test
+  public void create_WithNonAsciiChars() {
+    String key = "键";
+    String description = "测试用键";
+    LabelKey nonAsciiKey = LabelKey.create(key, description);
+    assertThat(nonAsciiKey.getKey()).isEqualTo(key);
+    assertThat(nonAsciiKey.getDescription()).isEqualTo(description);
+  }
+
+  @Test
+  public void create_Empty() {
+    LabelKey emptyKey = LabelKey.create("", "");
+    assertThat(emptyKey.getKey()).isEmpty();
+    assertThat(emptyKey.getDescription()).isEmpty();
+  }
+
+  @Test
+  public void testLabelKeyEquals() {
+    new EqualsTester()
+        .addEqualityGroup(LabelKey.create("foo", ""), LabelKey.create("foo", ""))
+        .addEqualityGroup(LabelKey.create("foo", "description"))
+        .addEqualityGroup(LabelKey.create("bar", ""))
+        .testEquals();
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/LabelValueTest.java
+++ b/api/src/test/java/openconsensus/metrics/LabelValueTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link LabelValue}. */
+@RunWith(JUnit4.class)
+public class LabelValueTest {
+
+  private static final LabelValue VALUE = LabelValue.create("value");
+  private static final LabelValue UNSET = LabelValue.create(null);
+  private static final LabelValue EMPTY = LabelValue.create("");
+
+  @Test
+  public void testGetValue() {
+    assertThat(VALUE.getValue()).isEqualTo("value");
+    assertThat(UNSET.getValue()).isNull();
+    assertThat(EMPTY.getValue()).isEmpty();
+  }
+
+  @Test
+  public void create_NoLengthConstraint() {
+    // We have a length constraint of 256-characters for TagValue. That constraint doesn't apply to
+    // LabelValue.
+    char[] chars = new char[300];
+    Arrays.fill(chars, 'v');
+    String value = new String(chars);
+    assertThat(LabelValue.create(value).getValue()).isEqualTo(value);
+  }
+
+  @Test
+  public void create_WithUnprintableChars() {
+    String value = "\2ab\3cd";
+    assertThat(LabelValue.create(value).getValue()).isEqualTo(value);
+  }
+
+  @Test
+  public void create_WithNonAsciiChars() {
+    String value = "值";
+    LabelValue nonAsciiValue = LabelValue.create(value);
+    assertThat(nonAsciiValue.getValue()).isEqualTo(value);
+  }
+
+  @Test
+  public void testLabelValueEquals() {
+    new EqualsTester()
+        .addEqualityGroup(LabelValue.create("foo"), LabelValue.create("foo"))
+        .addEqualityGroup(UNSET)
+        .addEqualityGroup(EMPTY)
+        .addEqualityGroup(LabelValue.create("bar"))
+        .testEquals();
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/LongGaugeTest.java
+++ b/api/src/test/java/openconsensus/metrics/LongGaugeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link LongGauge}. */
+@RunWith(JUnit4.class)
+public class LongGaugeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelKey> EMPTY_LABEL_KEYS = new ArrayList<LabelKey>();
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final MetricRegistry metricRegistry = NoopMetrics.newNoopMetricRegistry();
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
+    LongGauge longGauge =
+        metricRegistry.addLongGauge(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    longGauge.getOrCreateTimeSeries(null);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    LongGauge longGauge =
+        metricRegistry.addLongGauge(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    longGauge.getOrCreateTimeSeries(labelValues);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
+    LongGauge longGauge =
+        metricRegistry.addLongGauge(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    longGauge.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    LongGauge longGauge =
+        metricRegistry.addLongGauge(
+            NAME,
+            MetricOptions.builder()
+                .setDescription(DESCRIPTION)
+                .setLabelKeys(LABEL_KEY)
+                .setUnit(UNIT)
+                .build());
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    longGauge.removeTimeSeries(null);
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/MetricOptionsTest.java
+++ b/api/src/test/java/openconsensus/metrics/MetricOptionsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link MetricOptions}. */
+@RunWith(JUnit4.class)
+public class MetricOptionsTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String DESCRIPTION = "test_description";
+  private static final String UNIT = "1";
+  private static final LabelKey LABEL_KEY = LabelKey.create("test_key", "test key description");
+  private static final List<LabelKey> LABEL_KEYS = Collections.singletonList(LABEL_KEY);
+  private static final LabelValue LABEL_VALUE = LabelValue.create("test_value");
+  private static final Map<LabelKey, LabelValue> CONSTANT_LABELS =
+      Collections.singletonMap(LabelKey.create("test_key_1", "test key description"), LABEL_VALUE);
+
+  @Test
+  public void nullDescription() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("description");
+    MetricOptions.builder().setDescription(null).build();
+  }
+
+  @Test
+  public void nullUnit() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("unit");
+    MetricOptions.builder().setUnit(null).build();
+  }
+
+  @Test
+  public void nullLabelKeys() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelKeys");
+    MetricOptions.builder().setLabelKeys(null).build();
+  }
+
+  @Test
+  public void labelKeys_WithNullElement() {
+    List<LabelKey> labelKeys = Collections.singletonList(null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelKeys elements");
+    MetricOptions.builder().setLabelKeys(labelKeys).build();
+  }
+
+  @Test
+  public void sameLabelKeyInLabelsKey() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid LabelKey in labelKeys");
+    MetricOptions.builder()
+        .setLabelKeys(Arrays.asList(LABEL_KEY, LABEL_KEY))
+        .setConstantLabels(Collections.singletonMap(LABEL_KEY, LABEL_VALUE))
+        .build();
+  }
+
+  @Test
+  public void nullConstantLabels() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("constantLabels");
+    MetricOptions.builder().setConstantLabels(null).build();
+  }
+
+  @Test
+  public void constantLabels_WithNullKey() {
+    Map<LabelKey, LabelValue> constantLabels = Collections.singletonMap(null, LABEL_VALUE);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("constantLabels elements");
+    MetricOptions.builder().setConstantLabels(constantLabels).build();
+  }
+
+  @Test
+  public void constantLabels_WithNullValue() {
+    Map<LabelKey, LabelValue> constantLabels = Collections.singletonMap(LABEL_KEY, null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("constantLabels elements");
+    MetricOptions.builder().setConstantLabels(constantLabels).build();
+  }
+
+  @Test
+  public void sameLabelKeyInConstantLabelsAndLabelsKey() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid LabelKey in constantLabels");
+    MetricOptions.builder()
+        .setLabelKeys(LABEL_KEYS)
+        .setConstantLabels(Collections.singletonMap(LABEL_KEY, LABEL_VALUE))
+        .build();
+  }
+
+  @Test
+  public void setAndGet() {
+    MetricOptions metricOptions =
+        MetricOptions.builder()
+            .setDescription(DESCRIPTION)
+            .setUnit(UNIT)
+            .setLabelKeys(LABEL_KEYS)
+            .setConstantLabels(CONSTANT_LABELS)
+            .build();
+    assertThat(metricOptions.getDescription()).isEqualTo(DESCRIPTION);
+    assertThat(metricOptions.getUnit()).isEqualTo(UNIT);
+    assertThat(metricOptions.getLabelKeys()).isEqualTo(LABEL_KEYS);
+    assertThat(metricOptions.getConstantLabels()).isEqualTo(CONSTANT_LABELS);
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/MetricRegistryTest.java
+++ b/api/src/test/java/openconsensus/metrics/MetricRegistryTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link MetricRegistry}. */
+@RunWith(JUnit4.class)
+public class MetricRegistryTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "test_name";
+  private static final String NAME_2 = "test_name2";
+  private static final String DESCRIPTION = "test_description";
+  private static final String UNIT = "1";
+  private static final LabelKey LABEL_KEY = LabelKey.create("test_key", "test key description");
+  private static final List<LabelKey> LABEL_KEYS = Collections.singletonList(LABEL_KEY);
+  private static final LabelValue LABEL_VALUE = LabelValue.create("test_value");
+  private static final LabelValue LABEL_VALUE_2 = LabelValue.create("test_value_2");
+  private static final List<LabelValue> LABEL_VALUES = Collections.singletonList(LABEL_VALUE);
+  private static final Map<LabelKey, LabelValue> CONSTANT_LABELS =
+      Collections.singletonMap(
+          LabelKey.create("test_key_1", "test key description"), LABEL_VALUE_2);
+  private static final MetricOptions METRIC_OPTIONS =
+      MetricOptions.builder()
+          .setDescription(DESCRIPTION)
+          .setUnit(UNIT)
+          .setLabelKeys(LABEL_KEYS)
+          .setConstantLabels(CONSTANT_LABELS)
+          .build();
+  private final MetricRegistry metricRegistry = NoopMetrics.newNoopMetricRegistry();
+
+  @Test
+  public void noopAddLongGauge_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addLongGauge(null, METRIC_OPTIONS);
+  }
+
+  @Test
+  public void noopAddDoubleGauge_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addDoubleGauge(null, METRIC_OPTIONS);
+  }
+
+  @Test
+  public void noopAddDerivedLongGauge_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addDerivedLongGauge(null, METRIC_OPTIONS);
+  }
+
+  @Test
+  public void noopAddDerivedDoubleGauge_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addDerivedDoubleGauge(null, METRIC_OPTIONS);
+  }
+
+  @Test
+  public void noopAddDoubleCumulative_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addDoubleCumulative(null, METRIC_OPTIONS);
+  }
+
+  @Test
+  public void noopAddDerivedDoubleCumulative_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addDerivedDoubleCumulative(null, METRIC_OPTIONS);
+  }
+}

--- a/api/src/test/java/openconsensus/metrics/MetricsTest.java
+++ b/api/src/test/java/openconsensus/metrics/MetricsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Metrics}. */
+@RunWith(JUnit4.class)
+public class MetricsTest {
+
+  @Test
+  public void defaultMetricRegistry() {
+    assertThat(Metrics.getMetricRegistry())
+        .isInstanceOf(NoopMetrics.newNoopMetricRegistry().getClass());
+  }
+}

--- a/api/src/test/java/openconsensus/resource/ResourceTest.java
+++ b/api/src/test/java/openconsensus/resource/ResourceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.resource;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Resource}. */
+@RunWith(JUnit4.class)
+public class ResourceTest {
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  private static final Resource DEFAULT_RESOURCE =
+      Resource.create(Collections.<String, String>emptyMap());
+  private static final Resource DEFAULT_RESOURCE_1 =
+      Resource.create(Collections.singletonMap("a", "100"));
+  private Resource resource1;
+  private Resource resource2;
+
+  @Before
+  public void setUp() {
+    Map<String, String> labelMap1 = new HashMap<String, String>();
+    labelMap1.put("a", "1");
+    labelMap1.put("b", "2");
+    Map<String, String> labelMap2 = new HashMap<String, String>();
+    labelMap2.put("a", "1");
+    labelMap2.put("b", "3");
+    labelMap2.put("c", "4");
+    resource1 = Resource.create(labelMap1);
+    resource2 = Resource.create(labelMap2);
+  }
+
+  @Test
+  public void create() {
+    Map<String, String> labelMap = new HashMap<String, String>();
+    labelMap.put("a", "1");
+    labelMap.put("b", "2");
+    Resource resource = Resource.create(labelMap);
+    assertThat(resource.getLabels()).isNotNull();
+    assertThat(resource.getLabels().size()).isEqualTo(2);
+    assertThat(resource.getLabels()).isEqualTo(labelMap);
+
+    Resource resource1 = Resource.create(Collections.<String, String>emptyMap());
+    assertThat(resource1.getLabels()).isNotNull();
+    assertThat(resource1.getLabels()).isEmpty();
+  }
+
+  @Test
+  public void testResourceEquals() {
+    Map<String, String> labelMap1 = new HashMap<String, String>();
+    labelMap1.put("a", "1");
+    labelMap1.put("b", "2");
+    Map<String, String> labelMap2 = new HashMap<String, String>();
+    labelMap2.put("a", "1");
+    labelMap2.put("b", "3");
+    labelMap2.put("c", "4");
+    new EqualsTester()
+        .addEqualityGroup(Resource.create(labelMap1), Resource.create(labelMap1))
+        .addEqualityGroup(Resource.create(labelMap2))
+        .testEquals();
+  }
+
+  @Test
+  public void testMergeResources() {
+    Map<String, String> expectedLabelMap = new HashMap<String, String>();
+    expectedLabelMap.put("a", "1");
+    expectedLabelMap.put("b", "2");
+    expectedLabelMap.put("c", "4");
+
+    Resource resource = DEFAULT_RESOURCE.merge(resource1).merge(resource2);
+    assertThat(resource.getLabels()).isEqualTo(expectedLabelMap);
+  }
+
+  @Test
+  public void testMergeResources_Resource1() {
+    Map<String, String> expectedLabelMap = new HashMap<String, String>();
+    expectedLabelMap.put("a", "1");
+    expectedLabelMap.put("b", "2");
+
+    Resource resource = DEFAULT_RESOURCE.merge(resource1);
+    assertThat(resource.getLabels()).isEqualTo(expectedLabelMap);
+  }
+
+  @Test
+  public void testMergeResources_Resource1_Null() {
+    Map<String, String> expectedLabelMap = new HashMap<String, String>();
+    expectedLabelMap.put("a", "1");
+    expectedLabelMap.put("b", "3");
+    expectedLabelMap.put("c", "4");
+
+    Resource resource = DEFAULT_RESOURCE.merge(null).merge(resource2);
+    assertThat(resource.getLabels()).isEqualTo(expectedLabelMap);
+  }
+
+  @Test
+  public void testMergeResources_Resource2_Null() {
+    Map<String, String> expectedLabelMap = new HashMap<String, String>();
+    expectedLabelMap.put("a", "1");
+    expectedLabelMap.put("b", "2");
+
+    Resource resource = DEFAULT_RESOURCE.merge(resource1).merge(null);
+    assertThat(resource.getLabels()).isEqualTo(expectedLabelMap);
+  }
+}

--- a/api/src/test/java/openconsensus/stats/MeasureTest.java
+++ b/api/src/test/java/openconsensus/stats/MeasureTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Measure}. */
+@RunWith(JUnit4.class)
+public final class MeasureTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testConstants() {
+    assertThat(Measure.NAME_MAX_LENGTH).isEqualTo(255);
+  }
+
+  @Test
+  public void preventTooLongMeasureName() {
+    char[] chars = new char[Measure.NAME_MAX_LENGTH + 1];
+    Arrays.fill(chars, 'a');
+    String longName = String.valueOf(chars);
+    thrown.expect(IllegalArgumentException.class);
+    Measure.create(longName, "description", "1");
+  }
+
+  @Test
+  public void preventNonPrintableMeasureName() {
+    thrown.expect(IllegalArgumentException.class);
+    Measure.create("\2", "description", "1");
+  }
+
+  @Test
+  public void testMeasureComponents() {
+    Measure measurement = Measure.create("Foo", "The description of Foo", "Mbit/s");
+    assertThat(measurement.getName()).isEqualTo("Foo");
+    assertThat(measurement.getDescription()).isEqualTo("The description of Foo");
+    assertThat(measurement.getUnit()).isEqualTo("Mbit/s");
+  }
+
+  @Test
+  public void testMeasureEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            Measure.create("name", "description", "bit/s"),
+            Measure.create("name", "description", "bit/s"))
+        .addEqualityGroup(Measure.create("name", "description 2", "bit/s"))
+        .testEquals();
+  }
+}

--- a/api/src/test/java/openconsensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/openconsensus/stats/NoopStatsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.stats;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+import openconsensus.tags.Tag;
+import openconsensus.tags.TagKey;
+import openconsensus.tags.TagMap;
+import openconsensus.tags.TagValue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoopStats}. */
+@RunWith(JUnit4.class)
+public final class NoopStatsTest {
+  private static final Tag TAG =
+      Tag.create(
+          TagKey.create("key"), TagValue.create("value"), Tag.METADATA_UNLIMITED_PROPAGATION);
+  private static final Measure MEASURE = Measure.create("my measure", "description", "s");
+
+  private final TagMap tagMap =
+      new TagMap() {
+
+        @Override
+        public Iterator<Tag> getIterator() {
+          return Collections.<Tag>singleton(TAG).iterator();
+        }
+
+        @Nullable
+        @Override
+        public TagValue getTagValue(TagKey tagKey) {
+          return TagValue.create("value");
+        }
+      };
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void noopStatsRecorder_PutNegativeValue() {
+    List<Measurement> measurements = Collections.singletonList(Measurement.create(MEASURE, -5));
+    NoopStats.newNoopStatsRecorder().record(measurements, tagMap);
+  }
+
+  // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
+  // exception.
+  @Test
+  public void noopStatsRecorder_Record() {
+    List<Measurement> measurements = Collections.singletonList(Measurement.create(MEASURE, 5));
+    NoopStats.newNoopStatsRecorder().record(measurements, tagMap);
+  }
+
+  // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
+  // exception.
+  @Test
+  public void noopStatsRecorder_RecordWithCurrentContext() {
+    List<Measurement> measurements = Collections.singletonList(Measurement.create(MEASURE, 6));
+    NoopStats.newNoopStatsRecorder().record(measurements);
+  }
+
+  @Test
+  public void noopStatsRecorder_Record_DisallowNulltagMap() {
+    List<Measurement> measurements = Collections.singletonList(Measurement.create(MEASURE, 6));
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("tags");
+    NoopStats.newNoopStatsRecorder().record(measurements, null);
+  }
+}

--- a/api/src/test/java/openconsensus/stats/StatsTest.java
+++ b/api/src/test/java/openconsensus/stats/StatsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Stats}. */
+@RunWith(JUnit4.class)
+public final class StatsTest {
+
+  @Test
+  public void defaultValues() {
+    assertThat(Stats.getStatsRecorder()).isInstanceOf(NoopStats.newNoopStatsRecorder().getClass());
+  }
+}

--- a/api/src/test/java/openconsensus/tags/NoopTagsTest.java
+++ b/api/src/test/java/openconsensus/tags/NoopTagsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+import openconsensus.context.NoopScope;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoopTags}. */
+@RunWith(JUnit4.class)
+public final class NoopTagsTest {
+  private static final TagKey KEY = TagKey.create("key");
+  private static final TagValue VALUE = TagValue.create("value");
+
+  private static final TagMap TAG_MAP =
+      new TagMap() {
+
+        @Override
+        public Iterator<Tag> getIterator() {
+          return Arrays.<Tag>asList(Tag.create(KEY, VALUE, Tag.METADATA_UNLIMITED_PROPAGATION))
+              .iterator();
+        }
+
+        @Nullable
+        @Override
+        public TagValue getTagValue(TagKey tagKey) {
+          return VALUE;
+        }
+      };
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void noopTagger() {
+    Tagger noopTagger = NoopTags.newNoopTagger();
+    assertThat(asList(noopTagger.getCurrentTagMap())).isEmpty();
+    assertThat(asList(noopTagger.emptyBuilder().build())).isEmpty();
+    assertThat(asList(noopTagger.toBuilder(TAG_MAP).build())).isEmpty();
+    assertThat(asList(noopTagger.currentBuilder().build())).isEmpty();
+    assertThat(noopTagger.withTagMap(TAG_MAP)).isSameAs(NoopScope.getInstance());
+  }
+
+  @Test
+  public void noopTagger_ToBuilder_DisallowsNull() {
+    Tagger noopTagger = NoopTags.newNoopTagger();
+    thrown.expect(NullPointerException.class);
+    noopTagger.toBuilder(null);
+  }
+
+  @Test
+  public void noopTagger_WithTagMap_DisallowsNull() {
+    Tagger noopTagger = NoopTags.newNoopTagger();
+    thrown.expect(NullPointerException.class);
+    noopTagger.withTagMap(null);
+  }
+
+  @Test
+  public void noopTagMapBuilder_Put_DisallowsNullKey() {
+    TagMapBuilder noopBuilder = NoopTags.newNoopTagger().currentBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(null, VALUE, Tag.METADATA_UNLIMITED_PROPAGATION);
+  }
+
+  @Test
+  public void noopTagMapBuilder_Put_DisallowsNullValue() {
+    TagMapBuilder noopBuilder = NoopTags.newNoopTagger().currentBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(KEY, null, Tag.METADATA_UNLIMITED_PROPAGATION);
+  }
+
+  @Test
+  public void noopTagMapBuilder_Put_DisallowsNullTagMetadata() {
+    TagMapBuilder noopBuilder = NoopTags.newNoopTagger().currentBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(KEY, VALUE, null);
+  }
+
+  @Test
+  public void noopTagMapBuilder_Remove_DisallowsNullKey() {
+    TagMapBuilder noopBuilder = NoopTags.newNoopTagger().currentBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.remove(null);
+  }
+
+  private static List<Tag> asList(TagMap tags) {
+    return Lists.newArrayList(tags.getIterator());
+  }
+}

--- a/api/src/test/java/openconsensus/tags/TagKeyTest.java
+++ b/api/src/test/java/openconsensus/tags/TagKeyTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link TagKey}. */
+@RunWith(JUnit4.class)
+public final class TagKeyTest {
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testMaxLength() {
+    assertThat(TagKey.MAX_LENGTH).isEqualTo(255);
+  }
+
+  @Test
+  public void testGetName() {
+    assertThat(TagKey.create("foo").getName()).isEqualTo("foo");
+  }
+
+  @Test
+  public void create_AllowTagKeyNameWithMaxLength() {
+    char[] chars = new char[TagKey.MAX_LENGTH];
+    Arrays.fill(chars, 'k');
+    String key = new String(chars);
+    assertThat(TagKey.create(key).getName()).isEqualTo(key);
+  }
+
+  @Test
+  public void create_DisallowTagKeyNameOverMaxLength() {
+    char[] chars = new char[TagKey.MAX_LENGTH + 1];
+    Arrays.fill(chars, 'k');
+    String key = new String(chars);
+    thrown.expect(IllegalArgumentException.class);
+    TagKey.create(key);
+  }
+
+  @Test
+  public void create_DisallowUnprintableChars() {
+    thrown.expect(IllegalArgumentException.class);
+    TagKey.create("\2ab\3cd");
+  }
+
+  @Test
+  public void createString_DisallowEmpty() {
+    thrown.expect(IllegalArgumentException.class);
+    TagKey.create("");
+  }
+
+  @Test
+  public void testTagKeyEquals() {
+    new EqualsTester()
+        .addEqualityGroup(TagKey.create("foo"), TagKey.create("foo"))
+        .addEqualityGroup(TagKey.create("bar"))
+        .testEquals();
+  }
+}

--- a/api/src/test/java/openconsensus/tags/TagMetadataTest.java
+++ b/api/src/test/java/openconsensus/tags/TagMetadataTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import openconsensus.tags.TagMetadata.TagTtl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link TagMetadata}. */
+@RunWith(JUnit4.class)
+public class TagMetadataTest {
+
+  @Test
+  public void testGetTagTtl() {
+    TagMetadata tagMetadata = TagMetadata.create(TagTtl.NO_PROPAGATION);
+    assertThat(tagMetadata.getTagTtl()).isEqualTo(TagTtl.NO_PROPAGATION);
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            TagMetadata.create(TagTtl.NO_PROPAGATION), TagMetadata.create(TagTtl.NO_PROPAGATION))
+        .addEqualityGroup(TagMetadata.create(TagTtl.UNLIMITED_PROPAGATION))
+        .testEquals();
+  }
+}

--- a/api/src/test/java/openconsensus/tags/TagTest.java
+++ b/api/src/test/java/openconsensus/tags/TagTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import openconsensus.tags.TagMetadata.TagTtl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Tag}. */
+@RunWith(JUnit4.class)
+public final class TagTest {
+
+  private static final TagKey KEY = TagKey.create("KEY");
+  private static final TagKey KEY_2 = TagKey.create("KEY2");
+  private static final TagValue VALUE = TagValue.create("VALUE");
+  private static final TagValue VALUE_2 = TagValue.create("VALUE2");
+  private static final TagMetadata METADATA_UNLIMITED_PROPAGATION =
+      TagMetadata.create(TagTtl.UNLIMITED_PROPAGATION);
+  private static final TagMetadata METADATA_NO_PROPAGATION =
+      TagMetadata.create(TagTtl.NO_PROPAGATION);
+
+  @Test
+  public void testGetKey() {
+    assertThat(Tag.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION).getKey()).isEqualTo(KEY);
+  }
+
+  @Test
+  public void testGetTagMetadata() {
+    assertThat(Tag.create(KEY, VALUE, METADATA_NO_PROPAGATION).getTagMetadata())
+        .isEqualTo(METADATA_NO_PROPAGATION);
+  }
+
+  @Test
+  public void testTagEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            Tag.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION),
+            Tag.create(KEY, VALUE, METADATA_UNLIMITED_PROPAGATION))
+        .addEqualityGroup(Tag.create(KEY, VALUE_2, METADATA_UNLIMITED_PROPAGATION))
+        .addEqualityGroup(Tag.create(KEY_2, VALUE, METADATA_UNLIMITED_PROPAGATION))
+        .addEqualityGroup(Tag.create(KEY, VALUE, METADATA_NO_PROPAGATION))
+        .testEquals();
+  }
+}

--- a/api/src/test/java/openconsensus/tags/TagValueTest.java
+++ b/api/src/test/java/openconsensus/tags/TagValueTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link TagValue}. */
+@RunWith(JUnit4.class)
+public final class TagValueTest {
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testMaxLength() {
+    assertThat(TagValue.MAX_LENGTH).isEqualTo(255);
+  }
+
+  @Test
+  public void testAsString() {
+    assertThat(TagValue.create("foo").asString()).isEqualTo("foo");
+  }
+
+  @Test
+  public void create_AllowTagValueWithMaxLength() {
+    char[] chars = new char[TagValue.MAX_LENGTH];
+    Arrays.fill(chars, 'v');
+    String value = new String(chars);
+    assertThat(TagValue.create(value).asString()).isEqualTo(value);
+  }
+
+  @Test
+  public void create_DisallowTagValueOverMaxLength() {
+    char[] chars = new char[TagValue.MAX_LENGTH + 1];
+    Arrays.fill(chars, 'v');
+    String value = new String(chars);
+    thrown.expect(IllegalArgumentException.class);
+    TagValue.create(value);
+  }
+
+  @Test
+  public void disallowTagValueWithUnprintableChars() {
+    String value = "\2ab\3cd";
+    thrown.expect(IllegalArgumentException.class);
+    TagValue.create(value);
+  }
+
+  @Test
+  public void testTagValueEquals() {
+    new EqualsTester()
+        .addEqualityGroup(TagValue.create("foo"), TagValue.create("foo"))
+        .addEqualityGroup(TagValue.create("bar"))
+        .testEquals();
+  }
+}

--- a/api/src/test/java/openconsensus/tags/TagsTest.java
+++ b/api/src/test/java/openconsensus/tags/TagsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Tags}. */
+@RunWith(JUnit4.class)
+public class TagsTest {
+
+  @Test
+  public void defaultTagger() {
+    assertThat(Tags.getTagger()).isInstanceOf(NoopTags.newNoopTagger().getClass());
+  }
+}

--- a/api/src/test/java/openconsensus/tags/unsafe/ContextUtilsTest.java
+++ b/api/src/test/java/openconsensus/tags/unsafe/ContextUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.tags.unsafe;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Lists;
+import io.grpc.Context;
+import java.util.List;
+import openconsensus.tags.Tag;
+import openconsensus.tags.TagMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ContextUtils}. */
+@RunWith(JUnit4.class)
+public final class ContextUtilsTest {
+  @Test
+  public void testContextKeyName() {
+    // Context.Key.toString() returns the name.
+    assertThat(ContextUtils.TAG_MAP_KEY.toString()).isEqualTo("openconsensus-tag-map-key");
+  }
+
+  @Test
+  public void testGetCurrentTagMap_DefaultContext() {
+    TagMap tags = ContextUtils.TAG_MAP_KEY.get();
+    assertThat(tags).isNotNull();
+    assertThat(asList(tags)).isEmpty();
+  }
+
+  @Test
+  public void testGetCurrentTagMap_ContextSetToNull() {
+    Context orig = Context.current().withValue(ContextUtils.TAG_MAP_KEY, null).attach();
+    try {
+      TagMap tags = ContextUtils.TAG_MAP_KEY.get();
+      assertThat(tags).isNotNull();
+      assertThat(asList(tags)).isEmpty();
+    } finally {
+      Context.current().detach(orig);
+    }
+  }
+
+  private static List<Tag> asList(TagMap tags) {
+    return Lists.newArrayList(tags.getIterator());
+  }
+}

--- a/api/src/test/java/openconsensus/trace/AttributeValueTest.java
+++ b/api/src/test/java/openconsensus/trace/AttributeValueTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link AttributeValue}. */
+@RunWith(JUnit4.class)
+public class AttributeValueTest {
+
+  @Test
+  public void attributeValue_EqualsAndHashCode() {
+    EqualsTester tester = new EqualsTester();
+    tester.addEqualityGroup(
+        AttributeValue.stringAttributeValue("MyStringAttributeValue"),
+        AttributeValue.stringAttributeValue("MyStringAttributeValue"));
+    tester.addEqualityGroup(AttributeValue.stringAttributeValue("MyStringAttributeDiffValue"));
+    tester.addEqualityGroup(
+        AttributeValue.booleanAttributeValue(true), AttributeValue.booleanAttributeValue(true));
+    tester.addEqualityGroup(AttributeValue.booleanAttributeValue(false));
+    tester.addEqualityGroup(
+        AttributeValue.longAttributeValue(123456L), AttributeValue.longAttributeValue(123456L));
+    tester.addEqualityGroup(AttributeValue.longAttributeValue(1234567L));
+    tester.addEqualityGroup(
+        AttributeValue.doubleAttributeValue(1.23456), AttributeValue.doubleAttributeValue(1.23456));
+    tester.addEqualityGroup(AttributeValue.doubleAttributeValue(1.234567));
+    tester.testEquals();
+  }
+
+  @Test
+  public void attributeValue_ToString() {
+    AttributeValue attribute = AttributeValue.stringAttributeValue("MyStringAttributeValue");
+    assertThat(attribute.toString()).contains("MyStringAttributeValue");
+    attribute = AttributeValue.booleanAttributeValue(true);
+    assertThat(attribute.toString()).contains("true");
+    attribute = AttributeValue.longAttributeValue(123456L);
+    assertThat(attribute.toString()).contains("123456");
+    attribute = AttributeValue.doubleAttributeValue(1.23456);
+    assertThat(attribute.toString()).contains("1.23456");
+  }
+}

--- a/api/src/test/java/openconsensus/trace/BigendianEncodingTest.java
+++ b/api/src/test/java/openconsensus/trace/BigendianEncodingTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.CharBuffer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link BigendianEncoding}. */
+@RunWith(JUnit4.class)
+public class BigendianEncodingTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final long FIRST_LONG = 0x1213141516171819L;
+  private static final byte[] FIRST_BYTE_ARRAY =
+      new byte[] {0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19};
+  private static final char[] FIRST_CHAR_ARRAY =
+      new char[] {'1', '2', '1', '3', '1', '4', '1', '5', '1', '6', '1', '7', '1', '8', '1', '9'};
+  private static final long SECOND_LONG = 0xFFEEDDCCBBAA9988L;
+  private static final byte[] SECOND_BYTE_ARRAY =
+      new byte[] {
+        (byte) 0xFF, (byte) 0xEE, (byte) 0xDD, (byte) 0xCC,
+        (byte) 0xBB, (byte) 0xAA, (byte) 0x99, (byte) 0x88
+      };
+  private static final char[] SECOND_CHAR_ARRAY =
+      new char[] {'f', 'f', 'e', 'e', 'd', 'd', 'c', 'c', 'b', 'b', 'a', 'a', '9', '9', '8', '8'};
+  private static final byte[] BOTH_BYTE_ARRAY =
+      new byte[] {
+        0x12,
+        0x13,
+        0x14,
+        0x15,
+        0x16,
+        0x17,
+        0x18,
+        0x19,
+        (byte) 0xFF,
+        (byte) 0xEE,
+        (byte) 0xDD,
+        (byte) 0xCC,
+        (byte) 0xBB,
+        (byte) 0xAA,
+        (byte) 0x99,
+        (byte) 0x88
+      };
+  private static final char[] BOTH_CHAR_ARRAY =
+      new char[] {
+        '1', '2', '1', '3', '1', '4', '1', '5', '1', '6', '1', '7', '1', '8', '1', '9', 'f', 'f',
+        'e', 'e', 'd', 'd', 'c', 'c', 'b', 'b', 'a', 'a', '9', '9', '8', '8'
+      };
+
+  @Test
+  public void longToByteArray_Fails() {
+    // These contain bytes not in the decoding.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("array too small");
+    BigendianEncoding.longToByteArray(123, new byte[BigendianEncoding.LONG_BYTES], 1);
+  }
+
+  @Test
+  public void longToByteArray() {
+    byte[] result1 = new byte[BigendianEncoding.LONG_BYTES];
+    BigendianEncoding.longToByteArray(FIRST_LONG, result1, 0);
+    assertThat(result1).isEqualTo(FIRST_BYTE_ARRAY);
+
+    byte[] result2 = new byte[BigendianEncoding.LONG_BYTES];
+    BigendianEncoding.longToByteArray(SECOND_LONG, result2, 0);
+    assertThat(result2).isEqualTo(SECOND_BYTE_ARRAY);
+
+    byte[] result3 = new byte[2 * BigendianEncoding.LONG_BYTES];
+    BigendianEncoding.longToByteArray(FIRST_LONG, result3, 0);
+    BigendianEncoding.longToByteArray(SECOND_LONG, result3, BigendianEncoding.LONG_BYTES);
+    assertThat(result3).isEqualTo(BOTH_BYTE_ARRAY);
+  }
+
+  @Test
+  public void longFromByteArray_ArrayToSmall() {
+    // These contain bytes not in the decoding.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("array too small");
+    BigendianEncoding.longFromByteArray(new byte[BigendianEncoding.LONG_BYTES], 1);
+  }
+
+  @Test
+  public void longFromByteArray() {
+    assertThat(BigendianEncoding.longFromByteArray(FIRST_BYTE_ARRAY, 0)).isEqualTo(FIRST_LONG);
+
+    assertThat(BigendianEncoding.longFromByteArray(SECOND_BYTE_ARRAY, 0)).isEqualTo(SECOND_LONG);
+
+    assertThat(BigendianEncoding.longFromByteArray(BOTH_BYTE_ARRAY, 0)).isEqualTo(FIRST_LONG);
+
+    assertThat(BigendianEncoding.longFromByteArray(BOTH_BYTE_ARRAY, BigendianEncoding.LONG_BYTES))
+        .isEqualTo(SECOND_LONG);
+  }
+
+  @Test
+  public void toFromByteArray() {
+    toFromByteArrayValidate(0x8000000000000000L);
+    toFromByteArrayValidate(-1);
+    toFromByteArrayValidate(0);
+    toFromByteArrayValidate(1);
+    toFromByteArrayValidate(0x7FFFFFFFFFFFFFFFL);
+  }
+
+  @Test
+  public void longToBase16String() {
+    char[] chars1 = new char[BigendianEncoding.LONG_BASE16];
+    BigendianEncoding.longToBase16String(FIRST_LONG, chars1, 0);
+    assertThat(chars1).isEqualTo(FIRST_CHAR_ARRAY);
+
+    char[] chars2 = new char[BigendianEncoding.LONG_BASE16];
+    BigendianEncoding.longToBase16String(SECOND_LONG, chars2, 0);
+    assertThat(chars2).isEqualTo(SECOND_CHAR_ARRAY);
+
+    char[] chars3 = new char[2 * BigendianEncoding.LONG_BASE16];
+    BigendianEncoding.longToBase16String(FIRST_LONG, chars3, 0);
+    BigendianEncoding.longToBase16String(SECOND_LONG, chars3, BigendianEncoding.LONG_BASE16);
+    assertThat(chars3).isEqualTo(BOTH_CHAR_ARRAY);
+  }
+
+  @Test
+  public void longFromBase16String_InputTooSmall() {
+    // Valid base16 strings always have an even length.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("chars too small");
+    BigendianEncoding.longFromBase16String(
+        CharBuffer.wrap(new char[BigendianEncoding.LONG_BASE16]), 1);
+  }
+
+  @Test
+  public void longFromBase16String_UnrecongnizedCharacters() {
+    // These contain bytes not in the decoding.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("invalid character g");
+    BigendianEncoding.longFromBase16String("0123456789gbcdef", 0);
+  }
+
+  @Test
+  public void longFromBase16String() {
+    assertThat(BigendianEncoding.longFromBase16String(CharBuffer.wrap(FIRST_CHAR_ARRAY), 0))
+        .isEqualTo(FIRST_LONG);
+
+    assertThat(BigendianEncoding.longFromBase16String(CharBuffer.wrap(SECOND_CHAR_ARRAY), 0))
+        .isEqualTo(SECOND_LONG);
+
+    assertThat(BigendianEncoding.longFromBase16String(CharBuffer.wrap(BOTH_CHAR_ARRAY), 0))
+        .isEqualTo(FIRST_LONG);
+
+    assertThat(
+            BigendianEncoding.longFromBase16String(
+                CharBuffer.wrap(BOTH_CHAR_ARRAY), BigendianEncoding.LONG_BASE16))
+        .isEqualTo(SECOND_LONG);
+  }
+
+  @Test
+  public void toFromBase16String() {
+    toFromBase16StringValidate(0x8000000000000000L);
+    toFromBase16StringValidate(-1);
+    toFromBase16StringValidate(0);
+    toFromBase16StringValidate(1);
+    toFromBase16StringValidate(0x7FFFFFFFFFFFFFFFL);
+  }
+
+  private static void toFromByteArrayValidate(long value) {
+    byte[] array = new byte[BigendianEncoding.LONG_BYTES];
+    BigendianEncoding.longToByteArray(value, array, 0);
+    assertThat(BigendianEncoding.longFromByteArray(array, 0)).isEqualTo(value);
+  }
+
+  private static void toFromBase16StringValidate(long value) {
+    char[] dest = new char[BigendianEncoding.LONG_BASE16];
+    BigendianEncoding.longToBase16String(value, dest, 0);
+    assertThat(BigendianEncoding.longFromBase16String(CharBuffer.wrap(dest), 0)).isEqualTo(value);
+  }
+}

--- a/api/src/test/java/openconsensus/trace/BlankSpanTest.java
+++ b/api/src/test/java/openconsensus/trace/BlankSpanTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link BlankSpan}. */
+@RunWith(JUnit4.class)
+public class BlankSpanTest {
+  @Test
+  public void hasInvalidContextAndDefaultSpanOptions() {
+    assertThat(BlankSpan.INSTANCE.getContext()).isEqualTo(SpanContext.BLANK);
+  }
+
+  @Test
+  public void doNotCrash() {
+    BlankSpan.INSTANCE.setAttribute(
+        "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
+    BlankSpan.INSTANCE.setAttribute(
+        "MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
+    BlankSpan.INSTANCE.setAttribute("MyLongAttributeKey", AttributeValue.longAttributeValue(123));
+    BlankSpan.INSTANCE.addEvent(Event.create("event"));
+    BlankSpan.INSTANCE.addLink(Link.create(SpanContext.BLANK));
+    BlankSpan.INSTANCE.setStatus(Status.OK);
+    BlankSpan.INSTANCE.end();
+  }
+
+  @Test
+  public void blankSpan_ToString() {
+    assertThat(BlankSpan.INSTANCE.toString()).isEqualTo("BlankSpan");
+  }
+}

--- a/api/src/test/java/openconsensus/trace/LinkTest.java
+++ b/api/src/test/java/openconsensus/trace/LinkTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Link}. */
+@RunWith(JUnit4.class)
+public class LinkTest {
+  private final Map<String, AttributeValue> attributesMap = new HashMap<String, AttributeValue>();
+  private final Random random = new Random(1234);
+  private final Tracestate tracestate = Tracestate.builder().build();
+  private final SpanContext spanContext =
+      SpanContext.create(
+          TestUtils.generateRandomTraceId(random),
+          TestUtils.generateRandomSpanId(random),
+          TraceOptions.DEFAULT,
+          tracestate);
+
+  @Before
+  public void setUp() {
+    attributesMap.put("MyAttributeKey0", AttributeValue.stringAttributeValue("MyStringAttribute"));
+    attributesMap.put("MyAttributeKey1", AttributeValue.longAttributeValue(10));
+    attributesMap.put("MyAttributeKey2", AttributeValue.booleanAttributeValue(true));
+  }
+
+  @Test
+  public void create() {
+    Link link = Link.create(spanContext, attributesMap);
+    assertThat(link.getContext()).isEqualTo(spanContext);
+    assertThat(link.getAttributes()).isEqualTo(attributesMap);
+  }
+
+  @Test
+  public void link_EqualsAndHashCode() {
+    EqualsTester tester = new EqualsTester();
+    tester
+        .addEqualityGroup(Link.create(spanContext), Link.create(spanContext))
+        .addEqualityGroup(Link.create(SpanContext.BLANK))
+        .addEqualityGroup(
+            Link.create(spanContext, attributesMap), Link.create(spanContext, attributesMap));
+    tester.testEquals();
+  }
+
+  @Test
+  public void link_ToString() {
+    Link link = Link.create(spanContext, attributesMap);
+    assertThat(link.toString()).contains(spanContext.getTraceId().toString());
+    assertThat(link.toString()).contains(spanContext.getSpanId().toString());
+    assertThat(link.toString()).contains(attributesMap.toString());
+  }
+}

--- a/api/src/test/java/openconsensus/trace/SpanBuilderTest.java
+++ b/api/src/test/java/openconsensus/trace/SpanBuilderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.Callable;
+import openconsensus.trace.Span.Kind;
+import openconsensus.trace.samplers.Samplers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link SpanBuilder}. */
+@RunWith(JUnit4.class)
+// Need to suppress warnings for MustBeClosed because Java-6 does not support try-with-resources.
+@SuppressWarnings("MustBeClosedChecker")
+public class SpanBuilderTest {
+  private final Tracer tracer = Trace.getTracer();
+  private final SpanBuilder spanBuilder = tracer.spanBuilder("test");
+
+  @Test
+  public void startSpanAndRun() {
+    assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+    spanBuilder.startSpanAndRun(
+        new Runnable() {
+          @Override
+          public void run() {
+            assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+          }
+        });
+    assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+  }
+
+  @Test
+  public void startSpanAndCall() throws Exception {
+    final Object ret = new Object();
+    assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+    assertThat(
+            spanBuilder.startSpanAndCall(
+                new Callable<Object>() {
+                  @Override
+                  public Object call() throws Exception {
+                    assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+                    return ret;
+                  }
+                }))
+        .isEqualTo(ret);
+    assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+  }
+
+  @Test
+  public void doNotCrash_NoopImplementation() throws Exception {
+    SpanBuilder spanBuilder = tracer.spanBuilder("MySpanName");
+    spanBuilder.setRecordEvents(true);
+    spanBuilder.setSampler(Samplers.alwaysSample());
+    spanBuilder.setSpanKind(Kind.SERVER);
+    assertThat(spanBuilder.startSpan()).isSameAs(BlankSpan.INSTANCE);
+  }
+}

--- a/api/src/test/java/openconsensus/trace/SpanContextTest.java
+++ b/api/src/test/java/openconsensus/trace/SpanContextTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link SpanContext}. */
+@RunWith(JUnit4.class)
+public class SpanContextTest {
+  private static final byte[] firstTraceIdBytes =
+      new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
+  private static final byte[] secondTraceIdBytes =
+      new byte[] {0, 0, 0, 0, 0, 0, 0, '0', 0, 0, 0, 0, 0, 0, 0, 0};
+  private static final byte[] firstSpanIdBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
+  private static final byte[] secondSpanIdBytes = new byte[] {'0', 0, 0, 0, 0, 0, 0, 0};
+  private static final Tracestate firstTracestate = Tracestate.builder().set("foo", "bar").build();
+  private static final Tracestate secondTracestate = Tracestate.builder().set("foo", "baz").build();
+  private static final Tracestate emptyTracestate = Tracestate.builder().build();
+  private static final SpanContext first =
+      SpanContext.create(
+          TraceId.fromBytes(firstTraceIdBytes, 0),
+          SpanId.fromBytes(firstSpanIdBytes, 0),
+          TraceOptions.DEFAULT,
+          firstTracestate);
+  private static final SpanContext second =
+      SpanContext.create(
+          TraceId.fromBytes(secondTraceIdBytes, 0),
+          SpanId.fromBytes(secondSpanIdBytes, 0),
+          TraceOptions.builder().setIsSampled(true).build(),
+          secondTracestate);
+
+  @Test
+  public void invalidSpanContext() {
+    assertThat(SpanContext.BLANK.getTraceId()).isEqualTo(TraceId.INVALID);
+    assertThat(SpanContext.BLANK.getSpanId()).isEqualTo(SpanId.INVALID);
+    assertThat(SpanContext.BLANK.getTraceOptions()).isEqualTo(TraceOptions.DEFAULT);
+  }
+
+  @Test
+  public void isValid() {
+    assertThat(SpanContext.BLANK.isValid()).isFalse();
+    assertThat(
+            SpanContext.create(
+                    TraceId.fromBytes(firstTraceIdBytes, 0),
+                    SpanId.INVALID,
+                    TraceOptions.DEFAULT,
+                    emptyTracestate)
+                .isValid())
+        .isFalse();
+    assertThat(
+            SpanContext.create(
+                    TraceId.INVALID,
+                    SpanId.fromBytes(firstSpanIdBytes, 0),
+                    TraceOptions.DEFAULT,
+                    emptyTracestate)
+                .isValid())
+        .isFalse();
+    assertThat(first.isValid()).isTrue();
+    assertThat(second.isValid()).isTrue();
+  }
+
+  @Test
+  public void getTraceId() {
+    assertThat(first.getTraceId()).isEqualTo(TraceId.fromBytes(firstTraceIdBytes, 0));
+    assertThat(second.getTraceId()).isEqualTo(TraceId.fromBytes(secondTraceIdBytes, 0));
+  }
+
+  @Test
+  public void getSpanId() {
+    assertThat(first.getSpanId()).isEqualTo(SpanId.fromBytes(firstSpanIdBytes, 0));
+    assertThat(second.getSpanId()).isEqualTo(SpanId.fromBytes(secondSpanIdBytes, 0));
+  }
+
+  @Test
+  public void getTraceOptions() {
+    assertThat(first.getTraceOptions()).isEqualTo(TraceOptions.DEFAULT);
+    assertThat(second.getTraceOptions())
+        .isEqualTo(TraceOptions.builder().setIsSampled(true).build());
+  }
+
+  @Test
+  public void getTracestate() {
+    assertThat(first.getTracestate()).isEqualTo(firstTracestate);
+    assertThat(second.getTracestate()).isEqualTo(secondTracestate);
+  }
+
+  @Test
+  public void spanContext_EqualsAndHashCode() {
+    EqualsTester tester = new EqualsTester();
+    tester.addEqualityGroup(
+        first,
+        SpanContext.create(
+            TraceId.fromBytes(firstTraceIdBytes, 0),
+            SpanId.fromBytes(firstSpanIdBytes, 0),
+            TraceOptions.DEFAULT,
+            emptyTracestate),
+        SpanContext.create(
+            TraceId.fromBytes(firstTraceIdBytes, 0),
+            SpanId.fromBytes(firstSpanIdBytes, 0),
+            TraceOptions.builder().setIsSampled(false).build(),
+            firstTracestate));
+    tester.addEqualityGroup(
+        second,
+        SpanContext.create(
+            TraceId.fromBytes(secondTraceIdBytes, 0),
+            SpanId.fromBytes(secondSpanIdBytes, 0),
+            TraceOptions.builder().setIsSampled(true).build(),
+            secondTracestate));
+    tester.testEquals();
+  }
+
+  @Test
+  public void spanContext_ToString() {
+    assertThat(first.toString()).contains(TraceId.fromBytes(firstTraceIdBytes, 0).toString());
+    assertThat(first.toString()).contains(SpanId.fromBytes(firstSpanIdBytes, 0).toString());
+    assertThat(first.toString()).contains(TraceOptions.DEFAULT.toString());
+    assertThat(second.toString()).contains(TraceId.fromBytes(secondTraceIdBytes, 0).toString());
+    assertThat(second.toString()).contains(SpanId.fromBytes(secondSpanIdBytes, 0).toString());
+    assertThat(second.toString())
+        .contains(TraceOptions.builder().setIsSampled(true).build().toString());
+  }
+}

--- a/api/src/test/java/openconsensus/trace/SpanIdTest.java
+++ b/api/src/test/java/openconsensus/trace/SpanIdTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link SpanId}. */
+@RunWith(JUnit4.class)
+public class SpanIdTest {
+  private static final byte[] firstBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
+  private static final byte[] secondBytes = new byte[] {(byte) 0xFF, 0, 0, 0, 0, 0, 0, 'A'};
+  private static final SpanId first = SpanId.fromBytes(firstBytes, 0);
+  private static final SpanId second = SpanId.fromBytes(secondBytes, 0);
+
+  @Test
+  public void isValid() {
+    assertThat(SpanId.INVALID.isValid()).isFalse();
+    assertThat(first.isValid()).isTrue();
+    assertThat(second.isValid()).isTrue();
+  }
+
+  @Test
+  public void fromLowerBase16() {
+    assertThat(SpanId.fromLowerBase16("0000000000000000", 0)).isEqualTo(SpanId.INVALID);
+    assertThat(SpanId.fromLowerBase16("0000000000000061", 0)).isEqualTo(first);
+    assertThat(SpanId.fromLowerBase16("ff00000000000041", 0)).isEqualTo(second);
+  }
+
+  @Test
+  public void fromLowerBase16_WithOffset() {
+    assertThat(SpanId.fromLowerBase16("XX0000000000000000AA", 2)).isEqualTo(SpanId.INVALID);
+    assertThat(SpanId.fromLowerBase16("YY0000000000000061BB", 2)).isEqualTo(first);
+    assertThat(SpanId.fromLowerBase16("ZZff00000000000041CC", 2)).isEqualTo(second);
+  }
+
+  @Test
+  public void toLowerBase16() {
+    assertThat(SpanId.INVALID.toLowerBase16()).isEqualTo("0000000000000000");
+    assertThat(first.toLowerBase16()).isEqualTo("0000000000000061");
+    assertThat(second.toLowerBase16()).isEqualTo("ff00000000000041");
+  }
+
+  @Test
+  public void spanId_CompareTo() {
+    assertThat(first.compareTo(second)).isGreaterThan(0);
+    assertThat(second.compareTo(first)).isLessThan(0);
+    assertThat(first.compareTo(SpanId.fromBytes(firstBytes, 0))).isEqualTo(0);
+  }
+
+  @Test
+  public void spanId_EqualsAndHashCode() {
+    EqualsTester tester = new EqualsTester();
+    tester.addEqualityGroup(SpanId.INVALID, SpanId.INVALID);
+    tester.addEqualityGroup(
+        first, SpanId.fromBytes(Arrays.copyOf(firstBytes, firstBytes.length), 0));
+    tester.addEqualityGroup(
+        second, SpanId.fromBytes(Arrays.copyOf(secondBytes, secondBytes.length), 0));
+    tester.testEquals();
+  }
+
+  @Test
+  public void spanId_ToString() {
+    assertThat(SpanId.INVALID.toString()).contains("0000000000000000");
+    assertThat(first.toString()).contains("0000000000000061");
+    assertThat(second.toString()).contains("ff00000000000041");
+  }
+}

--- a/api/src/test/java/openconsensus/trace/StatusTest.java
+++ b/api/src/test/java/openconsensus/trace/StatusTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Status}. */
+@RunWith(JUnit4.class)
+public class StatusTest {
+  @Test
+  public void status_Ok() {
+    assertThat(Status.OK.getCanonicalCode()).isEqualTo(Status.CanonicalCode.OK);
+    assertThat(Status.OK.getDescription()).isNull();
+    assertThat(Status.OK.isOk()).isTrue();
+  }
+
+  @Test
+  public void createStatus_WithDescription() {
+    Status status = Status.UNKNOWN.withDescription("This is an error.");
+    assertThat(status.getCanonicalCode()).isEqualTo(Status.CanonicalCode.UNKNOWN);
+    assertThat(status.getDescription()).isEqualTo("This is an error.");
+    assertThat(status.isOk()).isFalse();
+  }
+
+  @Test
+  public void status_EqualsAndHashCode() {
+    EqualsTester tester = new EqualsTester();
+    tester.addEqualityGroup(Status.OK, Status.OK.withDescription(null));
+    tester.addEqualityGroup(
+        Status.CANCELLED.withDescription("ThisIsAnError"),
+        Status.CANCELLED.withDescription("ThisIsAnError"));
+    tester.addEqualityGroup(Status.UNKNOWN.withDescription("This is an error."));
+    tester.testEquals();
+  }
+}

--- a/api/src/test/java/openconsensus/trace/TestUtils.java
+++ b/api/src/test/java/openconsensus/trace/TestUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import java.util.Random;
+
+/** Common utilities for tests. */
+public final class TestUtils {
+
+  TestUtils() {}
+
+  /**
+   * Generates a random {@link TraceId}.
+   *
+   * @param random seed {@code Random}.
+   * @return a {@link TraceId}.
+   */
+  public static TraceId generateRandomTraceId(Random random) {
+    byte[] bytes = new byte[16];
+    random.nextBytes(bytes);
+    return TraceId.fromBytes(bytes, 0);
+  }
+
+  /**
+   * Generates a random {@link SpanId}.
+   *
+   * @param random seed {@code Random}.
+   * @return a {@link SpanId}.
+   */
+  public static SpanId generateRandomSpanId(Random random) {
+    byte[] bytes = new byte[8];
+    random.nextBytes(bytes);
+    return SpanId.fromBytes(bytes, 0);
+  }
+}

--- a/api/src/test/java/openconsensus/trace/TraceIdTest.java
+++ b/api/src/test/java/openconsensus/trace/TraceIdTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TraceId}. */
+@RunWith(JUnit4.class)
+public class TraceIdTest {
+  private static final byte[] firstBytes =
+      new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'a'};
+  private static final byte[] secondBytes =
+      new byte[] {(byte) 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'A'};
+  private static final TraceId first = TraceId.fromBytes(firstBytes, 0);
+  private static final TraceId second = TraceId.fromBytes(secondBytes, 0);
+
+  @Test
+  public void invalidTraceId() {
+    assertThat(TraceId.INVALID.getLowerLong()).isEqualTo(0);
+  }
+
+  @Test
+  public void isValid() {
+    assertThat(TraceId.INVALID.isValid()).isFalse();
+    assertThat(first.isValid()).isTrue();
+    assertThat(second.isValid()).isTrue();
+  }
+
+  @Test
+  public void getLowerLong() {
+    assertThat(first.getLowerLong()).isEqualTo(0);
+    assertThat(second.getLowerLong()).isEqualTo(-0xFF00000000000000L);
+  }
+
+  @Test
+  public void fromLowerBase16() {
+    assertThat(TraceId.fromLowerBase16("00000000000000000000000000000000", 0))
+        .isEqualTo(TraceId.INVALID);
+    assertThat(TraceId.fromLowerBase16("00000000000000000000000000000061", 0)).isEqualTo(first);
+    assertThat(TraceId.fromLowerBase16("ff000000000000000000000000000041", 0)).isEqualTo(second);
+  }
+
+  @Test
+  public void fromLowerBase16_WithOffset() {
+    assertThat(TraceId.fromLowerBase16("XX00000000000000000000000000000000CC", 2))
+        .isEqualTo(TraceId.INVALID);
+    assertThat(TraceId.fromLowerBase16("YY00000000000000000000000000000061AA", 2)).isEqualTo(first);
+    assertThat(TraceId.fromLowerBase16("ZZff000000000000000000000000000041BB", 2))
+        .isEqualTo(second);
+  }
+
+  @Test
+  public void toLowerBase16() {
+    assertThat(TraceId.INVALID.toLowerBase16()).isEqualTo("00000000000000000000000000000000");
+    assertThat(first.toLowerBase16()).isEqualTo("00000000000000000000000000000061");
+    assertThat(second.toLowerBase16()).isEqualTo("ff000000000000000000000000000041");
+  }
+
+  @Test
+  public void traceId_CompareTo() {
+    assertThat(first.compareTo(second)).isGreaterThan(0);
+    assertThat(second.compareTo(first)).isLessThan(0);
+    assertThat(first.compareTo(TraceId.fromBytes(firstBytes, 0))).isEqualTo(0);
+  }
+
+  @Test
+  public void traceId_EqualsAndHashCode() {
+    EqualsTester tester = new EqualsTester();
+    tester.addEqualityGroup(TraceId.INVALID, TraceId.INVALID);
+    tester.addEqualityGroup(
+        first, TraceId.fromBytes(Arrays.copyOf(firstBytes, firstBytes.length), 0));
+    tester.addEqualityGroup(
+        second, TraceId.fromBytes(Arrays.copyOf(secondBytes, secondBytes.length), 0));
+    tester.testEquals();
+  }
+
+  @Test
+  public void traceId_ToString() {
+    assertThat(TraceId.INVALID.toString()).contains("00000000000000000000000000000000");
+    assertThat(first.toString()).contains("00000000000000000000000000000061");
+    assertThat(second.toString()).contains("ff000000000000000000000000000041");
+  }
+}

--- a/api/src/test/java/openconsensus/trace/TraceOptionsTest.java
+++ b/api/src/test/java/openconsensus/trace/TraceOptionsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TraceOptions}. */
+@RunWith(JUnit4.class)
+public class TraceOptionsTest {
+  private static final byte FIRST_BYTE = (byte) 0xff;
+  private static final byte SECOND_BYTE = 1;
+  private static final byte THIRD_BYTE = 6;
+
+  @Test
+  public void getByte() {
+    assertThat(TraceOptions.DEFAULT.getByte()).isEqualTo(0);
+    assertThat(TraceOptions.builder().setIsSampled(false).build().getByte()).isEqualTo(0);
+    assertThat(TraceOptions.builder().setIsSampled(true).build().getByte()).isEqualTo(1);
+    assertThat(TraceOptions.builder().setIsSampled(true).setIsSampled(false).build().getByte())
+        .isEqualTo(0);
+    assertThat(TraceOptions.fromByte(FIRST_BYTE).getByte()).isEqualTo(-1);
+    assertThat(TraceOptions.fromByte(SECOND_BYTE).getByte()).isEqualTo(1);
+    assertThat(TraceOptions.fromByte(THIRD_BYTE).getByte()).isEqualTo(6);
+  }
+
+  @Test
+  public void isSampled() {
+    assertThat(TraceOptions.DEFAULT.isSampled()).isFalse();
+    assertThat(TraceOptions.builder().setIsSampled(true).build().isSampled()).isTrue();
+  }
+
+  @Test
+  public void toFromByte() {
+    assertThat(TraceOptions.fromByte(FIRST_BYTE).getByte()).isEqualTo(FIRST_BYTE);
+    assertThat(TraceOptions.fromByte(SECOND_BYTE).getByte()).isEqualTo(SECOND_BYTE);
+    assertThat(TraceOptions.fromByte(THIRD_BYTE).getByte()).isEqualTo(THIRD_BYTE);
+  }
+
+  @Test
+  public void toFromBase16() {
+    assertThat(TraceOptions.fromLowerBase16("ff", 0).toLowerBase16()).isEqualTo("ff");
+    assertThat(TraceOptions.fromLowerBase16("01", 0).toLowerBase16()).isEqualTo("01");
+    assertThat(TraceOptions.fromLowerBase16("06", 0).toLowerBase16()).isEqualTo("06");
+  }
+
+  @Test
+  public void builder_FromOptions() {
+    assertThat(
+            TraceOptions.builder(TraceOptions.fromByte(THIRD_BYTE))
+                .setIsSampled(true)
+                .build()
+                .getByte())
+        .isEqualTo(6 | 1);
+  }
+
+  @Test
+  public void traceOptions_EqualsAndHashCode() {
+    EqualsTester tester = new EqualsTester();
+    tester.addEqualityGroup(TraceOptions.DEFAULT);
+    tester.addEqualityGroup(
+        TraceOptions.fromByte(SECOND_BYTE), TraceOptions.builder().setIsSampled(true).build());
+    tester.addEqualityGroup(TraceOptions.fromByte(FIRST_BYTE));
+    tester.testEquals();
+  }
+
+  @Test
+  public void traceOptions_ToString() {
+    assertThat(TraceOptions.DEFAULT.toString()).contains("sampled=false");
+    assertThat(TraceOptions.builder().setIsSampled(true).build().toString())
+        .contains("sampled=true");
+  }
+}

--- a/api/src/test/java/openconsensus/trace/TraceTest.java
+++ b/api/src/test/java/openconsensus/trace/TraceTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Trace}. */
+@RunWith(JUnit4.class)
+public class TraceTest {
+
+  @Test
+  public void defaultTracer() {
+    assertThat(Trace.getTracer()).isInstanceOf(NoopTrace.newNoopTracer().getClass());
+  }
+}

--- a/api/src/test/java/openconsensus/trace/TracerTest.java
+++ b/api/src/test/java/openconsensus/trace/TracerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.Callable;
+import openconsensus.context.Scope;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Tracer}. */
+@RunWith(JUnit4.class)
+// Need to suppress warnings for MustBeClosed because Java-6 does not support try-with-resources.
+@SuppressWarnings("MustBeClosedChecker")
+public class TracerTest {
+  private static final Tracer noopTracer = NoopTrace.newNoopTracer();
+  private static final String SPAN_NAME = "MySpanName";
+
+  @Test
+  public void defaultGetCurrentSpan() {
+    assertThat(noopTracer.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
+  }
+
+  @Test
+  public void getCurrentSpan_WithSpan() {
+    assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+    Scope ws = noopTracer.withSpan(BlankSpan.INSTANCE);
+    try {
+      assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+    } finally {
+      ws.close();
+    }
+    assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+  }
+
+  @Test
+  public void wrapRunnable() {
+    Runnable runnable;
+    assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+    runnable =
+        noopTracer.withSpan(
+            BlankSpan.INSTANCE,
+            new Runnable() {
+              @Override
+              public void run() {
+                assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+              }
+            });
+    // When we run the runnable we will have the span in the current Context.
+    runnable.run();
+    assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+  }
+
+  @Test
+  public void wrapCallable() throws Exception {
+    final Object ret = new Object();
+    Callable<Object> callable;
+    assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+    callable =
+        noopTracer.withSpan(
+            BlankSpan.INSTANCE,
+            new Callable<Object>() {
+              @Override
+              public Object call() throws Exception {
+                assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+                return ret;
+              }
+            });
+    // When we call the callable we will have the span in the current Context.
+    assertThat(callable.call()).isEqualTo(ret);
+    assertThat(noopTracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void spanBuilderWithName_NullName() {
+    noopTracer.spanBuilder(null);
+  }
+
+  @Test
+  public void defaultSpanBuilderWithName() {
+    assertThat(noopTracer.spanBuilder(SPAN_NAME).startSpan()).isSameAs(BlankSpan.INSTANCE);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void spanBuilderWithParentAndName_NullName() {
+    noopTracer.spanBuilderWithExplicitParent(null, null);
+  }
+
+  @Test
+  public void defaultSpanBuilderWithParentAndName() {
+    assertThat(noopTracer.spanBuilderWithExplicitParent(SPAN_NAME, null).startSpan())
+        .isSameAs(BlankSpan.INSTANCE);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void spanBuilderWithRemoteParent_NullName() {
+    noopTracer.spanBuilderWithRemoteParent(null, null);
+  }
+
+  @Test
+  public void defaultSpanBuilderWithRemoteParent_NullParent() {
+    assertThat(noopTracer.spanBuilderWithRemoteParent(SPAN_NAME, null).startSpan())
+        .isSameAs(BlankSpan.INSTANCE);
+  }
+
+  @Test
+  public void defaultSpanBuilderWithRemoteParent() {
+    assertThat(noopTracer.spanBuilderWithRemoteParent(SPAN_NAME, SpanContext.BLANK).startSpan())
+        .isSameAs(BlankSpan.INSTANCE);
+  }
+}

--- a/api/src/test/java/openconsensus/trace/TracestateTest.java
+++ b/api/src/test/java/openconsensus/trace/TracestateTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Arrays;
+import openconsensus.trace.Tracestate.Entry;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Tracestate}. */
+@RunWith(JUnit4.class)
+public class TracestateTest {
+  private static final String FIRST_KEY = "key_1";
+  private static final String SECOND_KEY = "key_2";
+  private static final String FIRST_VALUE = "value.1";
+  private static final String SECOND_VALUE = "value.2";
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private static final Tracestate EMPTY = Tracestate.builder().build();
+  private final Tracestate firstTracestate = EMPTY.toBuilder().set(FIRST_KEY, FIRST_VALUE).build();
+  private final Tracestate secondTracestate =
+      EMPTY.toBuilder().set(SECOND_KEY, SECOND_VALUE).build();
+  private final Tracestate multiValueTracestate =
+      EMPTY.toBuilder().set(FIRST_KEY, FIRST_VALUE).set(SECOND_KEY, SECOND_VALUE).build();
+
+  @Test
+  public void get() {
+    assertThat(firstTracestate.get(FIRST_KEY)).isEqualTo(FIRST_VALUE);
+    assertThat(secondTracestate.get(SECOND_KEY)).isEqualTo(SECOND_VALUE);
+    assertThat(multiValueTracestate.get(FIRST_KEY)).isEqualTo(FIRST_VALUE);
+    assertThat(multiValueTracestate.get(SECOND_KEY)).isEqualTo(SECOND_VALUE);
+  }
+
+  @Test
+  public void getEntries() {
+    assertThat(firstTracestate.getEntries()).containsExactly(Entry.create(FIRST_KEY, FIRST_VALUE));
+    assertThat(secondTracestate.getEntries())
+        .containsExactly(Entry.create(SECOND_KEY, SECOND_VALUE));
+    assertThat(multiValueTracestate.getEntries())
+        .containsExactly(
+            Entry.create(FIRST_KEY, FIRST_VALUE), Entry.create(SECOND_KEY, SECOND_VALUE));
+  }
+
+  @Test
+  public void disallowsNullKey() {
+    thrown.expect(NullPointerException.class);
+    EMPTY.toBuilder().set(null, FIRST_VALUE).build();
+  }
+
+  @Test
+  public void invalidFirstKeyCharacter() {
+    thrown.expect(IllegalArgumentException.class);
+    EMPTY.toBuilder().set("1_key", FIRST_VALUE).build();
+  }
+
+  @Test
+  public void invalidKeyCharacters() {
+    thrown.expect(IllegalArgumentException.class);
+    EMPTY.toBuilder().set("kEy_1", FIRST_VALUE).build();
+  }
+
+  @Test
+  public void invalidKeySize() {
+    char[] chars = new char[257];
+    Arrays.fill(chars, 'a');
+    String longKey = new String(chars);
+    thrown.expect(IllegalArgumentException.class);
+    EMPTY.toBuilder().set(longKey, FIRST_VALUE).build();
+  }
+
+  @Test
+  public void allAllowedKeyCharacters() {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (char c = 'a'; c <= 'z'; c++) {
+      stringBuilder.append(c);
+    }
+    for (char c = '0'; c <= '9'; c++) {
+      stringBuilder.append(c);
+    }
+    stringBuilder.append('_');
+    stringBuilder.append('-');
+    stringBuilder.append('*');
+    stringBuilder.append('/');
+    String allowedKey = stringBuilder.toString();
+    assertThat(EMPTY.toBuilder().set(allowedKey, FIRST_VALUE).build().get(allowedKey))
+        .isEqualTo(FIRST_VALUE);
+  }
+
+  @Test
+  public void disallowsNullValue() {
+    thrown.expect(NullPointerException.class);
+    EMPTY.toBuilder().set(FIRST_KEY, null).build();
+  }
+
+  @Test
+  public void valueCannotContainEqual() {
+    thrown.expect(IllegalArgumentException.class);
+    EMPTY.toBuilder().set(FIRST_KEY, "my_vakue=5").build();
+  }
+
+  @Test
+  public void valueCannotContainComma() {
+    thrown.expect(IllegalArgumentException.class);
+    EMPTY.toBuilder().set(FIRST_KEY, "first,second").build();
+  }
+
+  @Test
+  public void valueCannotContainTrailingSpaces() {
+    thrown.expect(IllegalArgumentException.class);
+    EMPTY.toBuilder().set(FIRST_KEY, "first ").build();
+  }
+
+  @Test
+  public void invalidValueSize() {
+    char[] chars = new char[257];
+    Arrays.fill(chars, 'a');
+    String longValue = new String(chars);
+    thrown.expect(IllegalArgumentException.class);
+    EMPTY.toBuilder().set(FIRST_KEY, longValue).build();
+  }
+
+  @Test
+  public void allAllowedValueCharacters() {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (char c = ' ' /* '\u0020' */; c <= '~' /* '\u007E' */; c++) {
+      if (c == ',' || c == '=') {
+        continue;
+      }
+      stringBuilder.append(c);
+    }
+    String allowedValue = stringBuilder.toString();
+    assertThat(EMPTY.toBuilder().set(FIRST_KEY, allowedValue).build().get(FIRST_KEY))
+        .isEqualTo(allowedValue);
+  }
+
+  @Test
+  public void addEntry() {
+    assertThat(firstTracestate.toBuilder().set(SECOND_KEY, SECOND_VALUE).build())
+        .isEqualTo(multiValueTracestate);
+  }
+
+  @Test
+  public void updateEntry() {
+    assertThat(firstTracestate.toBuilder().set(FIRST_KEY, SECOND_VALUE).build().get(FIRST_KEY))
+        .isEqualTo(SECOND_VALUE);
+    Tracestate updatedMultiValueTracestate =
+        multiValueTracestate.toBuilder().set(FIRST_KEY, SECOND_VALUE).build();
+    assertThat(updatedMultiValueTracestate.get(FIRST_KEY)).isEqualTo(SECOND_VALUE);
+    assertThat(updatedMultiValueTracestate.get(SECOND_KEY)).isEqualTo(SECOND_VALUE);
+  }
+
+  @Test
+  public void addAndUpdateEntry() {
+    assertThat(
+            firstTracestate
+                .toBuilder()
+                .set(FIRST_KEY, SECOND_VALUE) // update the existing entry
+                .set(SECOND_KEY, FIRST_VALUE) // add a new entry
+                .build()
+                .getEntries())
+        .containsExactly(
+            Entry.create(FIRST_KEY, SECOND_VALUE), Entry.create(SECOND_KEY, FIRST_VALUE));
+  }
+
+  @Test
+  public void addSameKey() {
+    assertThat(
+            EMPTY
+                .toBuilder()
+                .set(FIRST_KEY, SECOND_VALUE) // update the existing entry
+                .set(FIRST_KEY, FIRST_VALUE) // add a new entry
+                .build()
+                .getEntries())
+        .containsExactly(Entry.create(FIRST_KEY, FIRST_VALUE));
+  }
+
+  @Test
+  public void remove() {
+    assertThat(multiValueTracestate.toBuilder().remove(SECOND_KEY).build())
+        .isEqualTo(firstTracestate);
+  }
+
+  @Test
+  public void addAndRemoveEntry() {
+    assertThat(
+            EMPTY
+                .toBuilder()
+                .set(FIRST_KEY, SECOND_VALUE) // update the existing entry
+                .remove(FIRST_KEY) // add a new entry
+                .build())
+        .isEqualTo(EMPTY);
+  }
+
+  @Test
+  public void remove_NullNotAllowed() {
+    thrown.expect(NullPointerException.class);
+    multiValueTracestate.toBuilder().remove(null).build();
+  }
+
+  @Test
+  public void tracestate_EqualsAndHashCode() {
+    EqualsTester tester = new EqualsTester();
+    tester.addEqualityGroup(EMPTY, EMPTY);
+    tester.addEqualityGroup(firstTracestate, EMPTY.toBuilder().set(FIRST_KEY, FIRST_VALUE).build());
+    tester.addEqualityGroup(
+        secondTracestate, EMPTY.toBuilder().set(SECOND_KEY, SECOND_VALUE).build());
+    tester.testEquals();
+  }
+
+  @Test
+  public void tracestate_ToString() {
+    assertThat(EMPTY.toString()).isEqualTo("Tracestate{entries=[]}");
+  }
+}

--- a/api/src/test/java/openconsensus/trace/samplers/SamplersTest.java
+++ b/api/src/test/java/openconsensus/trace/samplers/SamplersTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019, OpenConsensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package openconsensus.trace.samplers;
+
+import static com.google.common.truth.Truth.assertThat;
+import static openconsensus.trace.TestUtils.generateRandomSpanId;
+import static openconsensus.trace.TestUtils.generateRandomTraceId;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import openconsensus.trace.Sampler;
+import openconsensus.trace.Span;
+import openconsensus.trace.SpanContext;
+import openconsensus.trace.SpanId;
+import openconsensus.trace.TraceId;
+import openconsensus.trace.TraceOptions;
+import openconsensus.trace.Tracestate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Samplers}. */
+@RunWith(JUnit4.class)
+public class SamplersTest {
+  private static final String SPAN_NAME = "MySpanName";
+  private static final int NUM_SAMPLE_TRIES = 1000;
+  private final Random random = new Random(1234);
+  private final TraceId traceId = generateRandomTraceId(random);
+  private final SpanId parentSpanId = generateRandomSpanId(random);
+  private final SpanId spanId = generateRandomSpanId(random);
+  private final Tracestate tracestate = Tracestate.builder().build();
+  private final SpanContext sampledSpanContext =
+      SpanContext.create(
+          traceId, parentSpanId, TraceOptions.builder().setIsSampled(true).build(), tracestate);
+  private final SpanContext notSampledSpanContext =
+      SpanContext.create(traceId, parentSpanId, TraceOptions.DEFAULT, tracestate);
+
+  @Test
+  public void alwaysSampleSampler_AlwaysReturnTrue() {
+    // Sampled parent.
+    assertThat(
+            Samplers.alwaysSample()
+                .shouldSample(
+                    sampledSpanContext,
+                    false,
+                    traceId,
+                    spanId,
+                    "Another name",
+                    Collections.<Span>emptyList()))
+        .isTrue();
+    // Not sampled parent.
+    assertThat(
+            Samplers.alwaysSample()
+                .shouldSample(
+                    notSampledSpanContext,
+                    false,
+                    traceId,
+                    spanId,
+                    "Yet another name",
+                    Collections.<Span>emptyList()))
+        .isTrue();
+  }
+
+  @Test
+  public void alwaysSampleSampler_ToString() {
+    assertThat(Samplers.alwaysSample().toString()).isEqualTo("AlwaysSampleSampler");
+  }
+
+  @Test
+  public void neverSampleSampler_AlwaysReturnFalse() {
+    // Sampled parent.
+    assertThat(
+            Samplers.neverSample()
+                .shouldSample(
+                    sampledSpanContext,
+                    false,
+                    traceId,
+                    spanId,
+                    "bar",
+                    Collections.<Span>emptyList()))
+        .isFalse();
+    // Not sampled parent.
+    assertThat(
+            Samplers.neverSample()
+                .shouldSample(
+                    notSampledSpanContext,
+                    false,
+                    traceId,
+                    spanId,
+                    "quux",
+                    Collections.<Span>emptyList()))
+        .isFalse();
+  }
+
+  @Test
+  public void neverSampleSampler_ToString() {
+    assertThat(Samplers.neverSample().toString()).isEqualTo("NeverSampleSampler");
+  }
+
+  // Applies the given sampler to NUM_SAMPLE_TRIES random traceId/spanId pairs.
+  private static void assertSamplerSamplesWithProbability(
+      Sampler sampler, SpanContext parent, List<Span> parentLinks, double probability) {
+    Random random = new Random(1234);
+    int count = 0; // Count of spans with sampling enabled
+    for (int i = 0; i < NUM_SAMPLE_TRIES; i++) {
+      if (sampler.shouldSample(
+          parent,
+          false,
+          generateRandomTraceId(random),
+          generateRandomSpanId(random),
+          SPAN_NAME,
+          parentLinks)) {
+        count++;
+      }
+    }
+    double proportionSampled = (double) count / NUM_SAMPLE_TRIES;
+    // Allow for a large amount of slop (+/- 10%) in number of sampled traces, to avoid flakiness.
+    assertThat(proportionSampled < probability + 0.1 && proportionSampled > probability - 0.1)
+        .isTrue();
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ subprojects {
         grpcVersion = '1.20.0'
         autoValueVersion = '1.6.2'
         opentracingVersion = '0.32.0'
+        guavaVersion = '26.0-android'
 
         libraries = [
                 auto_value: "com.google.auto.value:auto-value:${autoValueVersion}",
@@ -111,6 +112,7 @@ subprojects {
                 opentracing: "io.opentracing:opentracing-api:${opentracingVersion}",
 
                 // Test dependencies.
+                guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
                 junit: 'junit:junit:4.12',
                 mockito: 'org.mockito:mockito-core:1.9.5',
                 truth: 'com.google.truth:truth:0.42',
@@ -132,7 +134,8 @@ subprojects {
 
         testCompile libraries.junit,
                 libraries.mockito,
-                libraries.truth
+                libraries.truth,
+                libraries.guava_testlib
 
         // The ErrorProne plugin defaults to the latest, which would break our
         // build if error prone releases a new version with a new check


### PR DESCRIPTION
Fixes https://github.com/bogdandrutu/openconsensus/issues/105.


Pretty much a copy-and-paste of https://github.com/census-instrumentation/opencensus-java/tree/master/api/src/test/java/io/opencensus, with updating a few tests to match the current APIs.