### PR TITLE
Make core classes interfaces.

### DIFF
--- a/api/src/main/java/openconsensus/context/propagation/BinaryFormat.java
+++ b/api/src/main/java/openconsensus/context/propagation/BinaryFormat.java
@@ -21,7 +21,7 @@ package openconsensus.context.propagation;
  *
  * @since 0.1.0
  */
-public abstract class BinaryFormat<V> {
+public interface BinaryFormat<V> {
 
   /**
    * Serializes the {@code value} into the on-the-wire representation.
@@ -30,7 +30,7 @@ public abstract class BinaryFormat<V> {
    * @return the on-the-wire representation of a {@code value}.
    * @since 0.1.0
    */
-  public abstract byte[] toByteArray(V value);
+  byte[] toByteArray(V value);
 
   /**
    * Creates a value from the given on-the-wire encoded representation.
@@ -42,5 +42,5 @@ public abstract class BinaryFormat<V> {
    * @return a value deserialized from {@code bytes}.
    * @since 0.1.0
    */
-  public abstract V fromByteArray(byte[] bytes);
+  V fromByteArray(byte[] bytes);
 }

--- a/api/src/main/java/openconsensus/context/propagation/TextFormat.java
+++ b/api/src/main/java/openconsensus/context/propagation/TextFormat.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  *
  * @since 0.1.0
  */
-public abstract class TextFormat<V> {
+public interface TextFormat<V> {
   /**
    * The propagation fields defined. If your carrier is reused, you should delete the fields here
    * before calling {@link #inject(Object, Object, Setter)} )}.
@@ -45,7 +45,7 @@ public abstract class TextFormat<V> {
   // The use cases of this are:
   // * allow pre-allocation of fields, especially in systems like gRPC Metadata
   // * allow a single-pass over an iterator
-  public abstract List<String> fields();
+  List<String> fields();
 
   /**
    * Injects the value downstream. For example, as http headers.
@@ -56,7 +56,7 @@ public abstract class TextFormat<V> {
    * @param <C> carrier of propagation fields, such as an http request
    * @since 0.1.0
    */
-  public abstract <C> void inject(V value, C carrier, Setter<C> setter);
+  <C> void inject(V value, C carrier, Setter<C> setter);
 
   /**
    * Class that allows a {@code TextFormat} to set propagated fields into a carrier.
@@ -67,7 +67,7 @@ public abstract class TextFormat<V> {
    * @param <C> carrier of propagation fields, such as an http request
    * @since 0.1.0
    */
-  public abstract static class Setter<C> {
+  public interface Setter<C> {
 
     /**
      * Replaces a propagated field with the given value.
@@ -80,7 +80,7 @@ public abstract class TextFormat<V> {
      * @param value the value of the field.
      * @since 0.1.0
      */
-    public abstract void put(C carrier, String key, String value);
+    void put(C carrier, String key, String value);
   }
 
   /**
@@ -95,10 +95,10 @@ public abstract class TextFormat<V> {
    * @return the extracted value.
    * @since 0.1.0
    */
-  public abstract <C> V extract(C carrier, Getter<C> getter);
+  <C> V extract(C carrier, Getter<C> getter);
 
   /**
-   * Class that allows a {@code TextFormat} to read propagated fields from a carrier.
+   * Interface that allows a {@code TextFormat} to read propagated fields from a carrier.
    *
    * <p>{@code Getter} is stateless and allows to be saved as a constant to avoid runtime
    * allocations.
@@ -106,7 +106,7 @@ public abstract class TextFormat<V> {
    * @param <C> carrier of propagation fields, such as an http request.
    * @since 0.1.0
    */
-  public abstract static class Getter<C> {
+  public interface Getter<C> {
 
     /**
      * Returns the first value of the given propagation {@code key} or returns {@code null}.
@@ -117,6 +117,6 @@ public abstract class TextFormat<V> {
      * @since 0.1.0
      */
     @Nullable
-    public abstract String get(C carrier, String key);
+    String get(C carrier, String key);
   }
 }

--- a/api/src/main/java/openconsensus/tags/NoopTags.java
+++ b/api/src/main/java/openconsensus/tags/NoopTags.java
@@ -116,7 +116,7 @@ public final class NoopTags {
 
   @Immutable
   private static final class NoopBinaryFormat
-      extends openconsensus.context.propagation.BinaryFormat<TagMap> {
+      implements openconsensus.context.propagation.BinaryFormat<TagMap> {
     static final byte[] EMPTY_BYTE_ARRAY = {};
 
     @Override
@@ -134,7 +134,7 @@ public final class NoopTags {
 
   @Immutable
   private static final class NoopTextFormat
-      extends openconsensus.context.propagation.TextFormat<TagMap> {
+      implements openconsensus.context.propagation.TextFormat<TagMap> {
     @Override
     public List<String> fields() {
       return Collections.emptyList();

--- a/api/src/main/java/openconsensus/trace/BlankSpan.java
+++ b/api/src/main/java/openconsensus/trace/BlankSpan.java
@@ -29,7 +29,7 @@ import openconsensus.internal.Utils;
  * @since 0.1.0
  */
 @Immutable
-public final class BlankSpan extends Span {
+public final class BlankSpan implements Span {
   /**
    * Singleton instance of this class.
    *

--- a/api/src/main/java/openconsensus/trace/NoopTrace.java
+++ b/api/src/main/java/openconsensus/trace/NoopTrace.java
@@ -47,7 +47,7 @@ public final class NoopTrace {
   }
 
   // No-Op implementation of the Tracer.
-  private static final class NoopTracer extends Tracer {
+  private static final class NoopTracer implements Tracer {
     private static final BinaryFormat<SpanContext> BINARY_FORMAT = new NoopBinaryFormat();
     private static final TextFormat<SpanContext> TEXT_FORMAT = new NoopTextFormat();
 
@@ -116,7 +116,7 @@ public final class NoopTrace {
   }
 
   // Noop implementation of SpanBuilder.
-  private static final class NoopSpanBuilder extends SpanBuilder {
+  private static final class NoopSpanBuilder implements SpanBuilder {
     static NoopSpanBuilder createWithParent(String spanName, @Nullable Span parent) {
       return new NoopSpanBuilder(spanName);
     }
@@ -171,7 +171,7 @@ public final class NoopTrace {
     }
   }
 
-  private static final class NoopBinaryFormat extends BinaryFormat<SpanContext> {
+  private static final class NoopBinaryFormat implements BinaryFormat<SpanContext> {
 
     @Override
     public byte[] toByteArray(SpanContext spanContext) {
@@ -188,7 +188,7 @@ public final class NoopTrace {
     private NoopBinaryFormat() {}
   }
 
-  private static final class NoopTextFormat extends TextFormat<SpanContext> {
+  private static final class NoopTextFormat implements TextFormat<SpanContext> {
 
     private NoopTextFormat() {}
 

--- a/api/src/main/java/openconsensus/trace/Span.java
+++ b/api/src/main/java/openconsensus/trace/Span.java
@@ -19,7 +19,7 @@ package openconsensus.trace;
 import java.util.Map;
 
 /**
- * An abstract class that represents a span. It has an associated {@link SpanContext}.
+ * An interface that represents a span. It has an associated {@link SpanContext}.
  *
  * <p>Spans are created by the {@link SpanBuilder#startSpan} method.
  *
@@ -27,7 +27,7 @@ import java.util.Map;
  *
  * @since 0.1.0
  */
-public abstract class Span {
+public interface Span {
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
    * the key, the old value is replaced by the specified value.
@@ -36,7 +36,7 @@ public abstract class Span {
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  public abstract void setAttribute(String key, String value);
+  void setAttribute(String key, String value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -46,7 +46,7 @@ public abstract class Span {
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  public abstract void setAttribute(String key, long value);
+  void setAttribute(String key, long value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -56,7 +56,7 @@ public abstract class Span {
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  public abstract void setAttribute(String key, double value);
+  void setAttribute(String key, double value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -66,7 +66,7 @@ public abstract class Span {
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  public abstract void setAttribute(String key, boolean value);
+  void setAttribute(String key, boolean value);
 
   /**
    * Sets an attribute to the {@code Span}. If the {@code Span} previously contained a mapping for
@@ -76,7 +76,7 @@ public abstract class Span {
    * @param value the value for this attribute.
    * @since 0.1.0
    */
-  public abstract void setAttribute(String key, AttributeValue value);
+  void setAttribute(String key, AttributeValue value);
 
   /**
    * Adds an event to the {@code Span}.
@@ -84,7 +84,7 @@ public abstract class Span {
    * @param name the name of the event.
    * @since 0.1.0
    */
-  public abstract void addEvent(String name);
+  void addEvent(String name);
 
   /**
    * Adds an event to the {@code Span}.
@@ -94,7 +94,7 @@ public abstract class Span {
    *     the {@code Span} as for {@code setAttributes()}.
    * @since 0.1.0
    */
-  public abstract void addEvent(String name, Map<String, AttributeValue> attributes);
+  void addEvent(String name, Map<String, AttributeValue> attributes);
 
   /**
    * Adds an event to the {@code Span}.
@@ -102,7 +102,7 @@ public abstract class Span {
    * @param event the event to add.
    * @since 0.1.0
    */
-  public abstract void addEvent(Event event);
+  void addEvent(Event event);
 
   /**
    * Adds a {@link Link} to the {@code Span}.
@@ -113,7 +113,7 @@ public abstract class Span {
    * @param link the link to add.
    * @since 0.1.0
    */
-  public abstract void addLink(Link link);
+  void addLink(Link link);
 
   /**
    * Sets the {@link Status} to the {@code Span}.
@@ -126,7 +126,7 @@ public abstract class Span {
    * @param status the {@link Status} to set.
    * @since 0.1.0
    */
-  public abstract void setStatus(Status status);
+  void setStatus(Status status);
 
   /**
    * Updates the {@code Span} name.
@@ -139,7 +139,7 @@ public abstract class Span {
    * @param name the {@code Span} name.
    * @since 0.1
    */
-  public abstract void updateName(String name);
+  void updateName(String name);
 
   /**
    * Marks the end of {@code Span} execution with the default options.
@@ -149,7 +149,7 @@ public abstract class Span {
    *
    * @since 0.1.0
    */
-  public abstract void end();
+  void end();
 
   /**
    * Returns the {@code SpanContext} associated with this {@code Span}.
@@ -157,7 +157,7 @@ public abstract class Span {
    * @return the {@code SpanContext} associated with this {@code Span}.
    * @since 0.1.0
    */
-  public abstract SpanContext getContext();
+  SpanContext getContext();
 
   /**
    * Returns {@code true} if this {@code Span} records events (e.g, {@link #addEvent(String)}.
@@ -165,7 +165,7 @@ public abstract class Span {
    * @return {@code true} if this {@code Span} records events.
    * @since 0.1.0
    */
-  public abstract boolean isRecordingEvents();
+  boolean isRecordingEvents();
 
   /**
    * Type of span. Can be used to specify additional relationships between spans in addition to a

--- a/api/src/main/java/openconsensus/trace/SpanBuilder.java
+++ b/api/src/main/java/openconsensus/trace/SpanBuilder.java
@@ -107,7 +107,7 @@ import java.util.concurrent.Callable;
  *
  * @since 0.1.0
  */
-public abstract class SpanBuilder {
+public interface SpanBuilder {
 
   /**
    * Sets the {@link Sampler} to use. If not set, the implementation will provide a default.
@@ -119,7 +119,7 @@ public abstract class SpanBuilder {
    * @return this.
    * @since 0.1.0
    */
-  public abstract SpanBuilder setSampler(Sampler sampler);
+  SpanBuilder setSampler(Sampler sampler);
 
   /**
    * Adds a {@link Link} to the newly created {@code Span}.
@@ -132,7 +132,7 @@ public abstract class SpanBuilder {
    * @throws NullPointerException if {@code link} is {@code null}.
    * @since 0.1.0
    */
-  public abstract SpanBuilder addLink(Link link);
+  SpanBuilder addLink(Link link);
 
   /**
    * Adds a {@code List} of {@link Link}s to the newly created {@code Span}.
@@ -143,7 +143,7 @@ public abstract class SpanBuilder {
    * @since 0.1.0
    * @see #addLink(Link)
    */
-  public abstract SpanBuilder addLinks(List<Link> links);
+  SpanBuilder addLinks(List<Link> links);
 
   /**
    * Sets the option to record events even if not sampled for the newly created {@code Span}. If not
@@ -153,7 +153,7 @@ public abstract class SpanBuilder {
    * @return this.
    * @since 0.1.0
    */
-  public abstract SpanBuilder setRecordEvents(boolean recordEvents);
+  SpanBuilder setRecordEvents(boolean recordEvents);
 
   /**
    * Sets the {@link Span.Kind} for the newly created {@code Span}. If not called, the
@@ -163,7 +163,7 @@ public abstract class SpanBuilder {
    * @return this.
    * @since 0.1.0
    */
-  public abstract SpanBuilder setSpanKind(Span.Kind spanKind);
+  SpanBuilder setSpanKind(Span.Kind spanKind);
 
   /**
    * Starts a new {@link Span}.
@@ -193,7 +193,7 @@ public abstract class SpanBuilder {
    * @return the newly created {@code Span}.
    * @since 0.1.0
    */
-  public abstract Span startSpan();
+  Span startSpan();
 
   /**
    * Starts a new span and runs the given {@code Runnable} with the newly created {@code Span} as
@@ -220,7 +220,7 @@ public abstract class SpanBuilder {
    * @param runnable the {@code Runnable} to run in the {@code Span}.
    * @since 0.1.0
    */
-  public abstract void startSpanAndRun(final Runnable runnable);
+  void startSpanAndRun(final Runnable runnable);
 
   /**
    * Starts a new span and calls the given {@code Callable} with the newly created {@code Span} as
@@ -252,5 +252,5 @@ public abstract class SpanBuilder {
    * @throws Exception if the {@code Callable} throws an exception.
    * @since 0.1.0
    */
-  public abstract <V> V startSpanAndCall(Callable<V> callable) throws Exception;
+  <V> V startSpanAndCall(Callable<V> callable) throws Exception;
 }

--- a/api/src/main/java/openconsensus/trace/Tracer.java
+++ b/api/src/main/java/openconsensus/trace/Tracer.java
@@ -25,7 +25,7 @@ import openconsensus.context.propagation.TextFormat;
 import openconsensus.resource.Resource;
 
 /**
- * Tracer is a simple, thin class for {@link Span} creation and in-process context interaction.
+ * Tracer is a simple, interface for {@link Span} creation and in-process context interaction.
  *
  * <p>Users may choose to use manual or automatic Context propagation. Because of that this class
  * offers APIs to facilitate both usages.
@@ -73,7 +73,7 @@ import openconsensus.resource.Resource;
  *
  * @since 0.1.0
  */
-public abstract class Tracer {
+public interface Tracer {
   /**
    * Gets the current Span from the current Context.
    *
@@ -86,7 +86,7 @@ public abstract class Tracer {
    *     from the Context.
    * @since 0.1.0
    */
-  public abstract Span getCurrentSpan();
+  Span getCurrentSpan();
 
   /**
    * Enters the scope of code where the given {@link Span} is in the current Context, and returns an
@@ -139,7 +139,7 @@ public abstract class Tracer {
    * @since 0.1.0
    */
   @MustBeClosed
-  public abstract Scope withSpan(Span span);
+  Scope withSpan(Span span);
 
   /**
    * Returns a {@link Runnable} that runs the given task with the given {@code Span} in the current
@@ -202,7 +202,7 @@ public abstract class Tracer {
    * @return the {@code Runnable}.
    * @since 0.1.0
    */
-  public abstract Runnable withSpan(Span span, Runnable runnable);
+  Runnable withSpan(Span span, Runnable runnable);
 
   /**
    * Returns a {@link Callable} that runs the given task with the given {@code Span} in the current
@@ -266,7 +266,7 @@ public abstract class Tracer {
    * @return the {@code Callable}.
    * @since 0.1.0
    */
-  public abstract <V> Callable<V> withSpan(Span span, final Callable<V> callable);
+  <V> Callable<V> withSpan(Span span, final Callable<V> callable);
 
   /**
    * Returns a {@link SpanBuilder} to create and start a new child {@link Span} as a child of to the
@@ -288,7 +288,7 @@ public abstract class Tracer {
    * @throws NullPointerException if {@code spanName} is {@code null}.
    * @since 0.1.0
    */
-  public abstract SpanBuilder spanBuilder(String spanName);
+  SpanBuilder spanBuilder(String spanName);
 
   /**
    * Returns a {@link SpanBuilder} to create and start a new child {@link Span} (or root if parent
@@ -307,7 +307,7 @@ public abstract class Tracer {
    * @throws NullPointerException if {@code spanName} is {@code null}.
    * @since 0.1.0
    */
-  public abstract SpanBuilder spanBuilderWithExplicitParent(String spanName, @Nullable Span parent);
+  SpanBuilder spanBuilderWithExplicitParent(String spanName, @Nullable Span parent);
 
   /**
    * Returns a {@link SpanBuilder} to create and start a new child {@link Span} (or root if parent
@@ -328,7 +328,7 @@ public abstract class Tracer {
    * @throws NullPointerException if {@code spanName} is {@code null}.
    * @since 0.1.0
    */
-  public abstract SpanBuilder spanBuilderWithRemoteParent(
+  SpanBuilder spanBuilderWithRemoteParent(
       String spanName, @Nullable SpanContext remoteParentSpanContext);
 
   /**
@@ -337,7 +337,7 @@ public abstract class Tracer {
    *
    * @param resource Resource to be associated with all {@link Span} and {@link SpanData} objects.
    */
-  public abstract void setResource(Resource resource);
+  void setResource(Resource resource);
 
   /**
    * Gets the {@link Resource} that is associating with all the {@link Span} and {@link SpanData}
@@ -346,7 +346,7 @@ public abstract class Tracer {
    * @return {@link Resource} that is associating with all {@link Span} and {@link SpanData}
    *     objects.
    */
-  public abstract Resource getResource();
+  Resource getResource();
 
   /**
    * Records a {@link SpanData}. This API allows to send a pre-populated span object to the
@@ -356,7 +356,7 @@ public abstract class Tracer {
    *
    * @param span Span Data to be reported to all exporters.
    */
-  public abstract void recordSpanData(SpanData span);
+  void recordSpanData(SpanData span);
 
   /**
    * Returns the {@link BinaryFormat} for this implementation.
@@ -408,7 +408,7 @@ public abstract class Tracer {
    * @return the {@code BinaryFormat} for this implementation.
    * @since 0.1.0
    */
-  public abstract BinaryFormat<SpanContext> getBinaryFormat();
+  BinaryFormat<SpanContext> getBinaryFormat();
 
   /**
    * Returns the {@link TextFormat} for this implementation.
@@ -462,7 +462,5 @@ public abstract class Tracer {
    * @return the {@code TextFormat} for this implementation.
    * @since 0.1.0
    */
-  public abstract TextFormat<SpanContext> getTextFormat();
-
-  protected Tracer() {}
+  TextFormat<SpanContext> getTextFormat();
 }

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/Propagation.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/Propagation.java
@@ -45,7 +45,7 @@ final class Propagation {
   }
 
   static final class TextMapSetter
-      extends openconsensus.context.propagation.TextFormat.Setter<TextMap> {
+      implements openconsensus.context.propagation.TextFormat.Setter<TextMap> {
     private TextMapSetter() {}
 
     public static final TextMapSetter INSTANCE = new TextMapSetter();
@@ -59,7 +59,7 @@ final class Propagation {
   // We use Map<> instead of TextMap as we need to query a specified key, and iterating over
   // *all* values per key-query *might* be a bad idea.
   static final class TextMapGetter
-      extends openconsensus.context.propagation.TextFormat.Getter<Map<String, String>> {
+      implements openconsensus.context.propagation.TextFormat.Getter<Map<String, String>> {
     private TextMapGetter() {}
 
     public static final TextMapGetter INSTANCE = new TextMapGetter();


### PR DESCRIPTION
Addresses #19, for your consideration - it only converts the core classes to interfaces (leaving alone `TraceId`, `Event`, etc)