### PR TITLE
Revert "Remove long values from stats, not too much value added, only complexity. (#114)"

### DIFF
--- a/api/src/main/java/openconsensus/stats/Measure.java
+++ b/api/src/main/java/openconsensus/stats/Measure.java
@@ -27,7 +27,6 @@ import openconsensus.internal.Utils;
  * @since 0.1.0
  */
 @Immutable
-@AutoValue
 public abstract class Measure {
   /* VisibleForTesting */ static final int NAME_MAX_LENGTH = 255;
   private static final String ERROR_MESSAGE_INVALID_NAME =
@@ -74,31 +73,108 @@ public abstract class Measure {
   public abstract String getUnit();
 
   /**
-   * Returns a new {@link Measurement} for this {@code Measure}.
+   * Returns a {@code Type} corresponding to the underlying value of this {@code Measure}.
    *
-   * @param value the corresponding value for the {@code Measurement}.
-   * @return a new {@link Measurement} for this {@code Measure}.
+   * @return the {@code Type} for the value of this {@code Measure}.
+   * @since 0.1.0
    */
-  public final Measurement createMeasurement(double value) {
-    Utils.checkArgument(value >= 0.0, "Unsupported negative values.");
-    return Measurement.create(this, value);
+  public abstract Type getType();
+
+  // Prevents this class from being subclassed anywhere else.
+  private Measure() {}
+
+  /**
+   * {@link Measure} with {@code Double} typed values.
+   *
+   * @since 0.1.0
+   */
+  @Immutable
+  @AutoValue
+  public abstract static class MeasureDouble extends Measure {
+
+    MeasureDouble() {}
+
+    /**
+     * Constructs a new {@link MeasureDouble}.
+     *
+     * @param name name of {@code Measure}. Suggested format: {@code <web_host>/<path>}.
+     * @param description description of {@code Measure}.
+     * @param unit unit of {@code Measure}.
+     * @return a {@code MeasureDouble}.
+     * @since 0.1.0
+     */
+    public static MeasureDouble create(String name, String description, String unit) {
+      Utils.checkArgument(
+          StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
+          ERROR_MESSAGE_INVALID_NAME);
+      return new AutoValue_Measure_MeasureDouble(name, description, unit);
+    }
+
+    @Override
+    public abstract String getName();
+
+    @Override
+    public abstract String getDescription();
+
+    @Override
+    public abstract String getUnit();
+
+    @Override
+    public final Type getType() {
+      return Type.DOUBLE;
+    }
   }
 
   /**
-   * Constructs a new {@link Measure}.
+   * {@link Measure} with {@code Long} typed values.
    *
-   * @param name name of {@code Measure}. Suggested format: {@code <web_host>/<path>}.
-   * @param description description of {@code Measure}.
-   * @param unit unit of {@code Measure}.
-   * @return a {@code Measure}.
    * @since 0.1.0
    */
-  public static Measure create(String name, String description, String unit) {
-    Utils.checkArgument(
-        StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
-        ERROR_MESSAGE_INVALID_NAME);
-    return new AutoValue_Measure(name, description, unit);
+  @Immutable
+  @AutoValue
+  public abstract static class MeasureLong extends Measure {
+
+    MeasureLong() {}
+
+    /**
+     * Constructs a new {@link MeasureLong}.
+     *
+     * @param name name of {@code Measure}. Suggested format: {@code <web_host>/<path>}.
+     * @param description description of {@code Measure}.
+     * @param unit unit of {@code Measure}.
+     * @return a {@code MeasureLong}.
+     * @since 0.1.0
+     */
+    public static MeasureLong create(String name, String description, String unit) {
+      Utils.checkArgument(
+          StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
+          ERROR_MESSAGE_INVALID_NAME);
+      return new AutoValue_Measure_MeasureLong(name, description, unit);
+    }
+
+    @Override
+    public abstract String getName();
+
+    @Override
+    public abstract String getDescription();
+
+    @Override
+    public abstract String getUnit();
+
+    @Override
+    public final Type getType() {
+      return Type.LONG;
+    }
   }
 
-  protected Measure() {}
+  /**
+   * An enum that represents all the possible value types for a {@code Measure} or a {@code
+   * Measurement}.
+   *
+   * @since 0.1.0
+   */
+  public enum Type {
+    LONG,
+    DOUBLE
+  }
 }

--- a/api/src/main/java/openconsensus/stats/Measurement.java
+++ b/api/src/main/java/openconsensus/stats/Measurement.java
@@ -18,14 +18,15 @@ package openconsensus.stats;
 
 import com.google.auto.value.AutoValue;
 import javax.annotation.concurrent.Immutable;
+import openconsensus.stats.Measure.MeasureDouble;
+import openconsensus.stats.Measure.MeasureLong;
 
 /**
- * Immutable representation of a measurement.
+ * Immutable representation of a Measurement.
  *
  * @since 0.1.0
  */
 @Immutable
-@AutoValue
 public abstract class Measurement {
 
   /**
@@ -37,22 +38,98 @@ public abstract class Measurement {
   public abstract Measure getMeasure();
 
   /**
-   * Returns the value for the {@link Measurement}.
+   * Returns the double value for the {@link Measurement}.
    *
-   * @return the value.
+   * <p>This method should only be called with {@link MeasurementDouble}.
+   *
+   * @return the double value.
    * @since 0.1.0
    */
-  public abstract double getValue();
-
-  // Prevents this class from being subclassed anywhere else.
-  Measurement() {}
+  public double getDoubleValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
 
   /**
-   * Constructs a new {@link Measurement}.
+   * Returns the long value for the {@link Measurement}.
+   *
+   * <p>This method should only be called with {@link MeasurementLong}.
+   *
+   * @return the long value.
+   * @since 0.1.0
+   */
+  public long getLongValue() {
+    throw new UnsupportedOperationException(
+        String.format("This type can only return %s data", getType().name()));
+  }
+
+  /**
+   * Returns a {@code Measure.Type} corresponding to the underlying value of this {@code
+   * Measurement}.
+   *
+   * @return the {@code Measure.Type} for the value of this {@code Measurement}.
+   * @since 0.1.0
+   */
+  public abstract Measure.Type getType();
+
+  // Prevents this class from being subclassed anywhere else.
+  private Measurement() {}
+
+  /**
+   * {@code Double} typed {@link Measurement}.
    *
    * @since 0.1.0
    */
-  static Measurement create(Measure measure, double value) {
-    return new AutoValue_Measurement(measure, value);
+  @Immutable
+  @AutoValue
+  public abstract static class MeasurementDouble extends Measurement {
+    MeasurementDouble() {}
+
+    /**
+     * Constructs a new {@link MeasurementDouble}.
+     *
+     * @since 0.1.0
+     */
+    public static MeasurementDouble create(MeasureDouble measure, double value) {
+      return new AutoValue_Measurement_MeasurementDouble(measure, value, Measure.Type.DOUBLE);
+    }
+
+    @Override
+    public abstract MeasureDouble getMeasure();
+
+    @Override
+    public abstract double getDoubleValue();
+
+    @Override
+    public abstract Measure.Type getType();
+  }
+
+  /**
+   * {@code Long} typed {@link Measurement}.
+   *
+   * @since 0.1.0
+   */
+  @Immutable
+  @AutoValue
+  public abstract static class MeasurementLong extends Measurement {
+    MeasurementLong() {}
+
+    /**
+     * Constructs a new {@link MeasurementLong}.
+     *
+     * @since 0.1.0
+     */
+    public static MeasurementLong create(MeasureLong measure, long value) {
+      return new AutoValue_Measurement_MeasurementLong(measure, value, Measure.Type.LONG);
+    }
+
+    @Override
+    public abstract MeasureLong getMeasure();
+
+    @Override
+    public abstract long getLongValue();
+
+    @Override
+    public abstract Measure.Type getType();
   }
 }

--- a/api/src/test/java/openconsensus/stats/MeasureTest.java
+++ b/api/src/test/java/openconsensus/stats/MeasureTest.java
@@ -43,18 +43,18 @@ public final class MeasureTest {
     Arrays.fill(chars, 'a');
     String longName = String.valueOf(chars);
     thrown.expect(IllegalArgumentException.class);
-    Measure.create(longName, "description", "1");
+    Measure.MeasureDouble.create(longName, "description", "1");
   }
 
   @Test
   public void preventNonPrintableMeasureName() {
     thrown.expect(IllegalArgumentException.class);
-    Measure.create("\2", "description", "1");
+    Measure.MeasureDouble.create("\2", "description", "1");
   }
 
   @Test
   public void testMeasureComponents() {
-    Measure measurement = Measure.create("Foo", "The description of Foo", "Mbit/s");
+    Measure measurement = Measure.MeasureDouble.create("Foo", "The description of Foo", "Mbit/s");
     assertThat(measurement.getName()).isEqualTo("Foo");
     assertThat(measurement.getDescription()).isEqualTo("The description of Foo");
     assertThat(measurement.getUnit()).isEqualTo("Mbit/s");
@@ -64,9 +64,10 @@ public final class MeasureTest {
   public void testMeasureEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            Measure.create("name", "description", "bit/s"),
-            Measure.create("name", "description", "bit/s"))
-        .addEqualityGroup(Measure.create("name", "description 2", "bit/s"))
+            Measure.MeasureDouble.create("name", "description", "bit/s"),
+            Measure.MeasureDouble.create("name", "description", "bit/s"))
+        .addEqualityGroup(Measure.MeasureLong.create("name", "description", "bit/s"))
+        .addEqualityGroup(Measure.MeasureDouble.create("name", "description 2", "bit/s"))
         .testEquals();
   }
 }

--- a/api/src/test/java/openconsensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/openconsensus/stats/NoopStatsTest.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nullable;
+import openconsensus.stats.Measure.MeasureDouble;
+import openconsensus.stats.Measurement.MeasurementDouble;
 import openconsensus.tags.Tag;
 import openconsensus.tags.TagKey;
 import openconsensus.tags.TagMap;
@@ -36,7 +38,8 @@ public final class NoopStatsTest {
   private static final Tag TAG =
       Tag.create(
           TagKey.create("key"), TagValue.create("value"), Tag.METADATA_UNLIMITED_PROPAGATION);
-  private static final Measure MEASURE = Measure.create("my measure", "description", "s");
+  private static final MeasureDouble MEASURE =
+      MeasureDouble.create("my measure", "description", "s");
 
   private final TagMap tagMap =
       new TagMap() {
@@ -57,7 +60,8 @@ public final class NoopStatsTest {
 
   @Test
   public void noopStatsRecorder_PutNegativeValue() {
-    List<Measurement> measurements = Collections.singletonList(Measurement.create(MEASURE, -5));
+    List<Measurement> measurements =
+        Collections.<Measurement>singletonList(MeasurementDouble.create(MEASURE, -5));
     NoopStats.newNoopStatsRecorder().record(measurements, tagMap);
   }
 
@@ -65,7 +69,8 @@ public final class NoopStatsTest {
   // exception.
   @Test
   public void noopStatsRecorder_Record() {
-    List<Measurement> measurements = Collections.singletonList(Measurement.create(MEASURE, 5));
+    List<Measurement> measurements =
+        Collections.<Measurement>singletonList(MeasurementDouble.create(MEASURE, 5));
     NoopStats.newNoopStatsRecorder().record(measurements, tagMap);
   }
 
@@ -73,13 +78,15 @@ public final class NoopStatsTest {
   // exception.
   @Test
   public void noopStatsRecorder_RecordWithCurrentContext() {
-    List<Measurement> measurements = Collections.singletonList(Measurement.create(MEASURE, 6));
+    List<Measurement> measurements =
+        Collections.<Measurement>singletonList(MeasurementDouble.create(MEASURE, 6));
     NoopStats.newNoopStatsRecorder().record(measurements);
   }
 
   @Test
   public void noopStatsRecorder_Record_DisallowNulltagMap() {
-    List<Measurement> measurements = Collections.singletonList(Measurement.create(MEASURE, 6));
+    List<Measurement> measurements =
+        Collections.<Measurement>singletonList(MeasurementDouble.create(MEASURE, 6));
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("tags");
     NoopStats.newNoopStatsRecorder().record(measurements, null);


### PR DESCRIPTION
This reverts commit b06d6422931a0cebc47dce68d091ef496d7a20de.

Related to https://github.com/bogdandrutu/openconsensus/issues/185.