### PR TITLE
Restrict access to the key, add helper methods to interact with Context.

### DIFF
--- a/api/src/main/java/openconsensus/tags/unsafe/ContextUtils.java
+++ b/api/src/main/java/openconsensus/tags/unsafe/ContextUtils.java
@@ -17,6 +17,7 @@
 package openconsensus.tags.unsafe;
 
 import io.grpc.Context;
+import openconsensus.internal.Utils;
 import openconsensus.tags.EmptyTagMap;
 import openconsensus.tags.TagMap;
 
@@ -24,19 +25,36 @@ import openconsensus.tags.TagMap;
  * Utility methods for accessing the {@link TagMap} contained in the {@link io.grpc.Context}.
  *
  * <p>Most code should interact with the current context via the public APIs in {@link TagMap} and
- * avoid accessing {@link #TAG_MAP_KEY} directly.
+ * avoid accessing this class directly.
  *
  * @since 0.1.0
  */
 public final class ContextUtils {
-  private ContextUtils() {}
+  private static final Context.Key<TagMap> TAG_MAP_KEY =
+      Context.keyWithDefault("openconsensus-tag-map-key", EmptyTagMap.INSTANCE);
 
   /**
-   * The {@link io.grpc.Context.Key} used to interact with the {@code TagMap} contained in the
-   * {@link io.grpc.Context}.
+   * Creates a new {@code Context} with the given value set.
    *
+   * @param context the parent {@code Context}.
+   * @param tagMap the value to be set.
+   * @return a new context with the given value set.
    * @since 0.1.0
    */
-  public static final Context.Key<TagMap> TAG_MAP_KEY =
-      Context.keyWithDefault("openconsensus-tag-map-key", EmptyTagMap.INSTANCE);
+  public static Context withValue(Context context, TagMap tagMap) {
+    return Utils.checkNotNull(context, "context").withValue(TAG_MAP_KEY, tagMap);
+  }
+
+  /**
+   * Returns the value from the specified {@code Context}.
+   *
+   * @param context the specified {@code Context}.
+   * @return the value from the specified {@code Context}.
+   * @since 0.1.0
+   */
+  public static TagMap getValue(Context context) {
+    return TAG_MAP_KEY.get(context);
+  }
+
+  private ContextUtils() {}
 }

--- a/api/src/main/java/openconsensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/openconsensus/trace/unsafe/ContextUtils.java
@@ -17,6 +17,7 @@
 package openconsensus.trace.unsafe;
 
 import io.grpc.Context;
+import openconsensus.internal.Utils;
 import openconsensus.trace.BlankSpan;
 import openconsensus.trace.Span;
 import openconsensus.trace.Tracer;
@@ -30,14 +31,31 @@ import openconsensus.trace.Tracer;
  * @since 0.1.0
  */
 public final class ContextUtils {
-  // No instance of this class.
-  private ContextUtils() {}
+  private static final Context.Key<Span> CONTEXT_SPAN_KEY =
+      Context.keyWithDefault("openconsensus-trace-span-key", BlankSpan.INSTANCE);
 
   /**
-   * The {@link io.grpc.Context.Key} used to interact with {@link io.grpc.Context}.
+   * Creates a new {@code Context} with the given value set.
    *
+   * @param context the parent {@code Context}.
+   * @param span the value to be set.
+   * @return a new context with the given value set.
    * @since 0.1.0
    */
-  public static final Context.Key<Span> CONTEXT_SPAN_KEY =
-      Context.keyWithDefault("openconsensus-trace-span-key", BlankSpan.INSTANCE);
+  public static Context withValue(Context context, Span span) {
+    return Utils.checkNotNull(context, "context").withValue(CONTEXT_SPAN_KEY, span);
+  }
+
+  /**
+   * Returns the value from the specified {@code Context}.
+   *
+   * @param context the specified {@code Context}.
+   * @return the value from the specified {@code Context}.
+   * @since 0.1.0
+   */
+  public static Span getValue(Context context) {
+    return CONTEXT_SPAN_KEY.get(Utils.checkNotNull(context, "context"));
+  }
+
+  private ContextUtils() {}
 }

--- a/api/src/test/java/openconsensus/trace/unsafe/ContextUtilsTest.java
+++ b/api/src/test/java/openconsensus/trace/unsafe/ContextUtilsTest.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package openconsensus.tags.unsafe;
+package openconsensus.trace.unsafe;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import io.grpc.Context;
-import openconsensus.tags.TagMap;
+import openconsensus.trace.BlankSpan;
+import openconsensus.trace.Span;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,19 +29,19 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class ContextUtilsTest {
   @Test
-  public void testGetCurrentTagMap_DefaultContext() {
-    TagMap tags = ContextUtils.getValue(Context.current());
-    assertThat(tags).isNotNull();
-    assertThat(tags.getIterator().hasNext()).isFalse();
+  public void testGetCurrentSpan_DefaultContext() {
+    Span span = ContextUtils.getValue(Context.current());
+    assertThat(span).isNotNull();
+    assertThat(span).isInstanceOf(BlankSpan.class);
   }
 
   @Test
-  public void testGetCurrentTagMap_ContextSetToNull() {
+  public void testGetCurrentSpan_ContextSetToNull() {
     Context orig = ContextUtils.withValue(Context.current(), null).attach();
     try {
-      TagMap tags = ContextUtils.getValue(Context.current());
-      assertThat(tags).isNotNull();
-      assertThat(tags.getIterator().hasNext()).isFalse();
+      Span span = ContextUtils.getValue(Context.current());
+      assertThat(span).isNotNull();
+      assertThat(span).isInstanceOf(BlankSpan.class);
     } finally {
       Context.current().detach(orig);
     }


### PR DESCRIPTION
I've just realized how badly OC got hit by the mistake to expose the Key and gRPC using directly the key, will be a bit mess to change that.