### PR TITLE
Rename Cumulative to Counter, and use names like templates GaugeLong.

### DIFF
--- a/api/src/main/java/openconsensus/metrics/CounterDouble.java
+++ b/api/src/main/java/openconsensus/metrics/CounterDouble.java
@@ -20,10 +20,10 @@ import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Long Gauge metric, to report instantaneous measurement of an int64 value. Gauges can go both up
- * and down. The gauges values can be negative.
+ * Counter metric, to report instantaneous measurement of a double value. Cumulative values can go
+ * up or stay the same, but can never go down. Cumulative values cannot be negative.
  *
- * <p>Example 1: Create a Gauge with default labels.
+ * <p>Example 1: Create a Cumulative with default labels.
  *
  * <pre>{@code
  * class YourClass {
@@ -33,10 +33,11 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
  *
- *   LongGauge gauge = metricRegistry.addLongGauge("queue_size", "Pending jobs", "1", labelKeys);
+ *   CounterDouble cumulative = metricRegistry.addDoubleCumulative("processed_jobs",
+ *                       "Processed jobs", "1", labelKeys);
  *
  *   // It is recommended to keep a reference of a TimeSeries.
- *   LongGauge.TimeSeries defaultTimeSeries = gauge.getDefaultTimeSeries();
+ *   CounterDouble.TimeSeries defaultTimeSeries = cumulative.getDefaultTimeSeries();
  *
  *   void doWork() {
  *      // Your code here.
@@ -46,7 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * <p>Example 2: You can also use labels(keys and values) to track different types of metric.
+ * <p>Example 2: You can also use labels (keys and values) to track different types of metric.
  *
  * <pre>{@code
  * class YourClass {
@@ -57,10 +58,11 @@ import javax.annotation.concurrent.ThreadSafe;
  *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
  *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
  *
- *   LongGauge gauge = metricRegistry.addLongGauge("queue_size", "Pending jobs", "1", labelKeys);
+ *   CounterDouble cumulative = metricRegistry.addDoubleCumulative("processed_jobs",
+ *                       "Processed jobs", "1", labelKeys);
  *
  *   // It is recommended to keep a reference of a TimeSeries.
- *   LongGauge.TimeSeries inboundTimeSeries = gauge.getOrCreateTimeSeries(labelValues);
+ *   CounterDouble.TimeSeries inboundTimeSeries = cumulative.getOrCreateTimeSeries(labelValues);
  *
  *   void doSomeWork() {
  *      // Your code here.
@@ -73,7 +75,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @since 0.1.0
  */
 @ThreadSafe
-public interface LongGauge extends Metric<LongGauge.TimeSeries> {
+public interface CounterDouble extends Metric<CounterDouble.TimeSeries> {
 
   @Override
   TimeSeries getOrCreateTimeSeries(List<LabelValue> labelValues);
@@ -82,29 +84,32 @@ public interface LongGauge extends Metric<LongGauge.TimeSeries> {
   TimeSeries getDefaultTimeSeries();
 
   /**
-   * The value of a single point in the Gauge.TimeSeries.
+   * A {@code TimeSeries} for a {@code CounterDouble}.
    *
    * @since 0.1.0
    */
   interface TimeSeries {
 
     /**
-     * Adds the given value to the current value. The values can be negative.
+     * Adds the given value to the current value. The values cannot be negative.
      *
-     * @param amt the value to add
+     * @param delta the value to add
      * @since 0.1.0
      */
-    void add(long amt);
+    void add(double delta);
 
     /**
-     * Sets the given value.
+     * Sets the given value. The value must be larger than the current recorded value.
+     *
+     * <p>In general should be used in combination with {@link #setCallback(Runnable)} where the
+     * recorded value is guaranteed to be monotonically increasing.
      *
      * @param val the new value.
      * @since 0.1.0
      */
-    void set(long val);
+    void set(double val);
   }
 
-  /** Builder class for {@link LongGauge}. */
-  interface Builder extends Metric.Builder<Builder, LongGauge> {}
+  /** Builder class for {@link CounterDouble}. */
+  interface Builder extends Metric.Builder<Builder, CounterDouble> {}
 }

--- a/api/src/main/java/openconsensus/metrics/CounterLong.java
+++ b/api/src/main/java/openconsensus/metrics/CounterLong.java
@@ -18,10 +18,11 @@ package openconsensus.metrics;
 
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
+import openconsensus.metrics.CounterLong.TimeSeries;
 
 /**
- * Double Cumulative metric, to report instantaneous measurement of a double value. Cumulative
- * values can go up or stay the same, but can never go down. Cumulative values cannot be negative.
+ * Counter metric, to report instantaneous measurement of a long value. Cumulative values can go up
+ * or stay the same, but can never go down. Cumulative values cannot be negative.
  *
  * <p>Example 1: Create a Cumulative with default labels.
  *
@@ -33,11 +34,11 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
  *
- *   DoubleCumulative cumulative = metricRegistry.addDoubleCumulative("processed_jobs",
+ *   CounterLong cumulative = metricRegistry.addLongCumulative("processed_jobs",
  *                       "Processed jobs", "1", labelKeys);
  *
  *   // It is recommended to keep a reference of a TimeSeries.
- *   DoubleCumulative.TimeSeries defaultTimeSeries = cumulative.getDefaultTimeSeries();
+ *   CounterLong.TimeSeries defaultTimeSeries = cumulative.getDefaultTimeSeries();
  *
  *   void doWork() {
  *      // Your code here.
@@ -58,11 +59,11 @@ import javax.annotation.concurrent.ThreadSafe;
  *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
  *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
  *
- *   DoubleCumulative cumulative = metricRegistry.addDoubleCumulative("processed_jobs",
+ *   CounterLong cumulative = metricRegistry.addLongCumulative("processed_jobs",
  *                       "Processed jobs", "1", labelKeys);
  *
  *   // It is recommended to keep a reference of a TimeSeries.
- *   DoubleCumulative.TimeSeries inboundTimeSeries = cumulative.getOrCreateTimeSeries(labelValues);
+ *   CounterLong.TimeSeries inboundTimeSeries = cumulative.getOrCreateTimeSeries(labelValues);
  *
  *   void doSomeWork() {
  *      // Your code here.
@@ -75,7 +76,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * @since 0.1.0
  */
 @ThreadSafe
-public interface DoubleCumulative extends Metric<DoubleCumulative.TimeSeries> {
+public interface CounterLong extends Metric<TimeSeries> {
 
   @Override
   TimeSeries getOrCreateTimeSeries(List<LabelValue> labelValues);
@@ -84,7 +85,7 @@ public interface DoubleCumulative extends Metric<DoubleCumulative.TimeSeries> {
   TimeSeries getDefaultTimeSeries();
 
   /**
-   * A {@code TimeSeries} for a {@code DoubleCumulative}.
+   * The value of a single point in the Cumulative.TimeSeries.
    *
    * @since 0.1.0
    */
@@ -96,7 +97,7 @@ public interface DoubleCumulative extends Metric<DoubleCumulative.TimeSeries> {
      * @param delta the value to add
      * @since 0.1.0
      */
-    void add(double delta);
+    void add(long delta);
 
     /**
      * Sets the given value. The value must be larger than the current recorded value.
@@ -107,9 +108,9 @@ public interface DoubleCumulative extends Metric<DoubleCumulative.TimeSeries> {
      * @param val the new value.
      * @since 0.1.0
      */
-    void set(double val);
+    void set(long val);
   }
 
-  /** Builder class for {@link DoubleCumulative}. */
-  interface Builder extends Metric.Builder<Builder, DoubleCumulative> {}
+  /** Builder class for {@link CounterLong}. */
+  interface Builder extends Metric.Builder<Builder, CounterLong> {}
 }

--- a/api/src/main/java/openconsensus/metrics/GaugeDouble.java
+++ b/api/src/main/java/openconsensus/metrics/GaugeDouble.java
@@ -18,11 +18,11 @@ package openconsensus.metrics;
 
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
-import openconsensus.metrics.DoubleGauge.TimeSeries;
+import openconsensus.metrics.GaugeDouble.TimeSeries;
 
 /**
- * Double Gauge metric, to report instantaneous measurement of a double value. Gauges can go both up
- * and down. The gauges values can be negative.
+ * Gauge metric, to report instantaneous measurement of a double value. Gauges can go both up and
+ * down. The gauges values can be negative.
  *
  * <p>Example 1: Create a Gauge with default labels.
  *
@@ -34,11 +34,11 @@ import openconsensus.metrics.DoubleGauge.TimeSeries;
  *
  *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
  *
- *   DoubleGauge gauge = metricRegistry.addDoubleGauge("queue_size",
+ *   GaugeDouble gauge = metricRegistry.addDoubleGauge("queue_size",
  *                       "Pending jobs", "1", labelKeys);
  *
  *   // It is recommended to keep a reference of a TimeSeries.
- *   DoubleGauge.TimeSeries defaultTimeSeries = gauge.getDefaultTimeSeries();
+ *   GaugeDouble.TimeSeries defaultTimeSeries = gauge.getDefaultTimeSeries();
  *
  *   void doWork() {
  *      // Your code here.
@@ -59,11 +59,11 @@ import openconsensus.metrics.DoubleGauge.TimeSeries;
  *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
  *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
  *
- *   DoubleGauge gauge = metricRegistry.addDoubleGauge("queue_size",
+ *   GaugeDouble gauge = metricRegistry.addDoubleGauge("queue_size",
  *                       "Pending jobs", "1", labelKeys);
  *
  *   // It is recommended to keep a reference of a TimeSeries.
- *   DoubleGauge.TimeSeries inboundTimeSeries = gauge.getOrCreateTimeSeries(labelValues);
+ *   GaugeDouble.TimeSeries inboundTimeSeries = gauge.getOrCreateTimeSeries(labelValues);
  *
  *   void doSomeWork() {
  *      // Your code here.
@@ -76,7 +76,7 @@ import openconsensus.metrics.DoubleGauge.TimeSeries;
  * @since 0.1.0
  */
 @ThreadSafe
-public interface DoubleGauge extends Metric<TimeSeries> {
+public interface GaugeDouble extends Metric<TimeSeries> {
 
   @Override
   TimeSeries getOrCreateTimeSeries(List<LabelValue> labelValues);
@@ -85,7 +85,7 @@ public interface DoubleGauge extends Metric<TimeSeries> {
   TimeSeries getDefaultTimeSeries();
 
   /**
-   * A {@code TimeSeries} for a {@code DoubleGauge}.
+   * A {@code TimeSeries} for a {@code GaugeDouble}.
    *
    * @since 0.1.0
    */
@@ -108,6 +108,6 @@ public interface DoubleGauge extends Metric<TimeSeries> {
     void set(double val);
   }
 
-  /** Builder class for {@link LongGauge}. */
-  interface Builder extends Metric.Builder<Builder, DoubleGauge> {}
+  /** Builder class for {@link GaugeLong}. */
+  interface Builder extends Metric.Builder<Builder, GaugeDouble> {}
 }

--- a/api/src/main/java/openconsensus/metrics/GaugeLong.java
+++ b/api/src/main/java/openconsensus/metrics/GaugeLong.java
@@ -18,13 +18,12 @@ package openconsensus.metrics;
 
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
-import openconsensus.metrics.LongCumulative.TimeSeries;
 
 /**
- * Long Cumulative metric, to report instantaneous measurement of a long value. Cumulative values
- * can go up or stay the same, but can never go down. Cumulative values cannot be negative.
+ * Gauge metric, to report instantaneous measurement of an long value. Gauges can go both up and
+ * down. The gauges values can be negative.
  *
- * <p>Example 1: Create a Cumulative with default labels.
+ * <p>Example 1: Create a Gauge with default labels.
  *
  * <pre>{@code
  * class YourClass {
@@ -34,11 +33,10 @@ import openconsensus.metrics.LongCumulative.TimeSeries;
  *
  *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
  *
- *   LongCumulative cumulative = metricRegistry.addLongCumulative("processed_jobs",
- *                       "Processed jobs", "1", labelKeys);
+ *   GaugeLong gauge = metricRegistry.addLongGauge("queue_size", "Pending jobs", "1", labelKeys);
  *
  *   // It is recommended to keep a reference of a TimeSeries.
- *   LongCumulative.TimeSeries defaultTimeSeries = cumulative.getDefaultTimeSeries();
+ *   GaugeLong.TimeSeries defaultTimeSeries = gauge.getDefaultTimeSeries();
  *
  *   void doWork() {
  *      // Your code here.
@@ -48,7 +46,7 @@ import openconsensus.metrics.LongCumulative.TimeSeries;
  * }
  * }</pre>
  *
- * <p>Example 2: You can also use labels (keys and values) to track different types of metric.
+ * <p>Example 2: You can also use labels(keys and values) to track different types of metric.
  *
  * <pre>{@code
  * class YourClass {
@@ -59,11 +57,10 @@ import openconsensus.metrics.LongCumulative.TimeSeries;
  *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
  *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
  *
- *   LongCumulative cumulative = metricRegistry.addLongCumulative("processed_jobs",
- *                       "Processed jobs", "1", labelKeys);
+ *   GaugeLong gauge = metricRegistry.addLongGauge("queue_size", "Pending jobs", "1", labelKeys);
  *
  *   // It is recommended to keep a reference of a TimeSeries.
- *   LongCumulative.TimeSeries inboundTimeSeries = cumulative.getOrCreateTimeSeries(labelValues);
+ *   GaugeLong.TimeSeries inboundTimeSeries = gauge.getOrCreateTimeSeries(labelValues);
  *
  *   void doSomeWork() {
  *      // Your code here.
@@ -76,7 +73,7 @@ import openconsensus.metrics.LongCumulative.TimeSeries;
  * @since 0.1.0
  */
 @ThreadSafe
-public interface LongCumulative extends Metric<TimeSeries> {
+public interface GaugeLong extends Metric<GaugeLong.TimeSeries> {
 
   @Override
   TimeSeries getOrCreateTimeSeries(List<LabelValue> labelValues);
@@ -85,25 +82,22 @@ public interface LongCumulative extends Metric<TimeSeries> {
   TimeSeries getDefaultTimeSeries();
 
   /**
-   * The value of a single point in the Cumulative.TimeSeries.
+   * The value of a single point in the Gauge.TimeSeries.
    *
    * @since 0.1.0
    */
   interface TimeSeries {
 
     /**
-     * Adds the given value to the current value. The values cannot be negative.
+     * Adds the given value to the current value. The values can be negative.
      *
-     * @param delta the value to add
+     * @param amt the value to add
      * @since 0.1.0
      */
-    void add(long delta);
+    void add(long amt);
 
     /**
-     * Sets the given value. The value must be larger than the current recorded value.
-     *
-     * <p>In general should be used in combination with {@link #setCallback(Runnable)} where the
-     * recorded value is guaranteed to be monotonically increasing.
+     * Sets the given value.
      *
      * @param val the new value.
      * @since 0.1.0
@@ -111,6 +105,6 @@ public interface LongCumulative extends Metric<TimeSeries> {
     void set(long val);
   }
 
-  /** Builder class for {@link LongCumulative}. */
-  interface Builder extends Metric.Builder<Builder, LongCumulative> {}
+  /** Builder class for {@link GaugeLong}. */
+  interface Builder extends Metric.Builder<Builder, GaugeLong> {}
 }

--- a/api/src/main/java/openconsensus/metrics/Metric.java
+++ b/api/src/main/java/openconsensus/metrics/Metric.java
@@ -31,7 +31,7 @@ public interface Metric<T> {
    * method for every operations.
    *
    * @param labelValues the list of label values. The number of label values must be the same to
-   *     that of the label keys passed to {@link DoubleGauge.Builder#setLabelKeys(List)}.
+   *     that of the label keys passed to {@link GaugeDouble.Builder#setLabelKeys(List)}.
    * @return a {@code TimeSeries} the value of single gauge.
    * @throws NullPointerException if {@code labelValues} is null OR any element of {@code
    *     labelValues} is null.

--- a/api/src/main/java/openconsensus/metrics/MetricRegistry.java
+++ b/api/src/main/java/openconsensus/metrics/MetricRegistry.java
@@ -26,53 +26,48 @@ import openconsensus.resource.Resource;
 public interface MetricRegistry {
 
   /**
-   * Returns a builder for a {@link LongGauge} to be added to the registry. This is more convenient
-   * form when you want to manually increase and decrease values as per your service requirements.
+   * Returns a builder for a {@link GaugeLong} to be added to the registry.
    *
    * @param name the name of the metric.
-   * @return a {@code LongGauge.Builder}.
+   * @return a {@code GaugeLong.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @since 0.1.0
    */
-  LongGauge.Builder longGaugeBuilder(String name);
+  GaugeLong.Builder gaugeLongBuilder(String name);
 
   /**
-   * Returns a builder for a {@link DoubleGauge} to be added to the registry. This is more
-   * convenient form when you want to manually increase and decrease values as per your service
-   * requirements.
+   * Returns a builder for a {@link GaugeDouble} to be added to the registry.
    *
    * @param name the name of the metric.
-   * @return a {@code DoubleGauge.Builder}.
+   * @return a {@code GaugeDouble.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @since 0.1.0
    */
-  DoubleGauge.Builder doubleGaugeBuilder(String name);
+  GaugeDouble.Builder gaugeDoubleBuilder(String name);
 
   /**
-   * Returns a builder for a {@link DoubleCumulative} to be added to the registry. This is a more
-   * convenient form when you want to manually increase values as per your service requirements.
+   * Returns a builder for a {@link CounterDouble} to be added to the registry.
    *
    * @param name the name of the metric.
-   * @return a {@code DoubleCumulative.Builder}.
+   * @return a {@code CounterDouble.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @since 0.1.0
    */
-  DoubleCumulative.Builder doubleCumulativeBuilder(String name);
+  CounterDouble.Builder counterDoubleBuilder(String name);
 
   /**
-   * Returns a builder for a {@link LongCumulative} to be added to the registry. This is a more
-   * convenient form when you want to manually increase values as per your service requirements.
+   * Returns a builder for a {@link CounterLong} to be added to the registry.
    *
    * @param name the name of the metric.
-   * @return a {@code LongCumulative.Builder}.
+   * @return a {@code CounterLong.Builder}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
    * @since 0.1.0
    */
-  LongCumulative.Builder longCumulativeBuilder(String name);
+  CounterLong.Builder counterLongBuilder(String name);
 
   /** Builder class for the {@link MetricRegistry}. */
   interface Builder {

--- a/api/src/main/java/openconsensus/metrics/NoopMetrics.java
+++ b/api/src/main/java/openconsensus/metrics/NoopMetrics.java
@@ -49,27 +49,27 @@ public final class NoopMetrics {
 
   private static final class NoopMetricCollection implements MetricRegistry {
     @Override
-    public LongGauge.Builder longGaugeBuilder(String name) {
+    public GaugeLong.Builder gaugeLongBuilder(String name) {
       Utils.checkNotNull(name, "name");
-      return new NoopLongGauge.NoopBuilder();
+      return new NoopGaugeLong.NoopBuilder();
     }
 
     @Override
-    public DoubleGauge.Builder doubleGaugeBuilder(String name) {
+    public GaugeDouble.Builder gaugeDoubleBuilder(String name) {
       Utils.checkNotNull(name, "name");
-      return new NoopDoubleGauge.NoopBuilder();
+      return new NoopGaugeDouble.NoopBuilder();
     }
 
     @Override
-    public DoubleCumulative.Builder doubleCumulativeBuilder(String name) {
+    public CounterDouble.Builder counterDoubleBuilder(String name) {
       Utils.checkNotNull(name, "name");
-      return new NoopDoubleCumulative.NoopBuilder();
+      return new NoopCounterDouble.NoopBuilder();
     }
 
     @Override
-    public LongCumulative.Builder longCumulativeBuilder(String name) {
+    public CounterLong.Builder counterLongBuilder(String name) {
       Utils.checkNotNull(name, "name");
-      return new NoopLongCumulative.NoopBuilder();
+      return new NoopCounterLong.NoopBuilder();
     }
 
     private static final class Builder implements MetricRegistry.Builder {
@@ -94,12 +94,12 @@ public final class NoopMetrics {
     }
   }
 
-  /** No-op implementations of LongGauge class. */
-  private static final class NoopLongGauge implements LongGauge {
+  /** No-op implementations of GaugeLong class. */
+  private static final class NoopGaugeLong implements GaugeLong {
     private final int labelKeysSize;
 
     /** Creates a new {@code NoopTimeSeries}. */
-    private NoopLongGauge(int labelKeysSize) {
+    private NoopGaugeLong(int labelKeysSize) {
       this.labelKeysSize = labelKeysSize;
     }
 
@@ -140,7 +140,7 @@ public final class NoopMetrics {
       public void set(long val) {}
     }
 
-    private static final class NoopBuilder implements LongGauge.Builder {
+    private static final class NoopBuilder implements GaugeLong.Builder {
       private int labelKeysSize = 0;
 
       @Override
@@ -170,18 +170,18 @@ public final class NoopMetrics {
       }
 
       @Override
-      public LongGauge build() {
-        return new NoopLongGauge(labelKeysSize);
+      public GaugeLong build() {
+        return new NoopGaugeLong(labelKeysSize);
       }
     }
   }
 
-  /** No-op implementations of DoubleGauge class. */
-  private static final class NoopDoubleGauge implements DoubleGauge {
+  /** No-op implementations of GaugeDouble class. */
+  private static final class NoopGaugeDouble implements GaugeDouble {
     private final int labelKeysSize;
 
     /** Creates a new {@code NoopTimeSeries}. */
-    private NoopDoubleGauge(int labelKeysSize) {
+    private NoopGaugeDouble(int labelKeysSize) {
       this.labelKeysSize = labelKeysSize;
     }
 
@@ -222,7 +222,7 @@ public final class NoopMetrics {
       public void set(double val) {}
     }
 
-    private static final class NoopBuilder implements DoubleGauge.Builder {
+    private static final class NoopBuilder implements GaugeDouble.Builder {
       private int labelKeysSize = 0;
 
       @Override
@@ -252,18 +252,18 @@ public final class NoopMetrics {
       }
 
       @Override
-      public DoubleGauge build() {
-        return new NoopDoubleGauge(labelKeysSize);
+      public GaugeDouble build() {
+        return new NoopGaugeDouble(labelKeysSize);
       }
     }
   }
 
-  /** No-op implementations of DoubleCumulative class. */
-  private static final class NoopDoubleCumulative implements DoubleCumulative {
+  /** No-op implementations of CounterDouble class. */
+  private static final class NoopCounterDouble implements CounterDouble {
     private final int labelKeysSize;
 
     /** Creates a new {@code NoopTimeSeries}. */
-    private NoopDoubleCumulative(int labelKeysSize) {
+    private NoopCounterDouble(int labelKeysSize) {
       this.labelKeysSize = labelKeysSize;
     }
 
@@ -306,7 +306,7 @@ public final class NoopMetrics {
       public void set(double val) {}
     }
 
-    private static final class NoopBuilder implements DoubleCumulative.Builder {
+    private static final class NoopBuilder implements CounterDouble.Builder {
       private int labelKeysSize = 0;
 
       @Override
@@ -336,18 +336,18 @@ public final class NoopMetrics {
       }
 
       @Override
-      public DoubleCumulative build() {
-        return new NoopDoubleCumulative(labelKeysSize);
+      public CounterDouble build() {
+        return new NoopCounterDouble(labelKeysSize);
       }
     }
   }
 
-  /** No-op implementations of LongCumulative class. */
-  private static final class NoopLongCumulative implements LongCumulative {
+  /** No-op implementations of CounterLong class. */
+  private static final class NoopCounterLong implements CounterLong {
     private final int labelKeysSize;
 
     /** Creates a new {@code NoopTimeSeries}. */
-    private NoopLongCumulative(int labelKeysSize) {
+    private NoopCounterLong(int labelKeysSize) {
       this.labelKeysSize = labelKeysSize;
     }
 
@@ -390,7 +390,7 @@ public final class NoopMetrics {
       public void set(long val) {}
     }
 
-    private static final class NoopBuilder implements LongCumulative.Builder {
+    private static final class NoopBuilder implements CounterLong.Builder {
       private int labelKeysSize = 0;
 
       @Override
@@ -420,8 +420,8 @@ public final class NoopMetrics {
       }
 
       @Override
-      public LongCumulative build() {
-        return new NoopLongCumulative(labelKeysSize);
+      public CounterLong build() {
+        return new NoopCounterLong(labelKeysSize);
       }
     }
   }

--- a/api/src/test/java/openconsensus/metrics/CounterDoubleTest.java
+++ b/api/src/test/java/openconsensus/metrics/CounterDoubleTest.java
@@ -25,9 +25,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link LongGauge}. */
+/** Unit tests for {@link CounterDouble}. */
 @RunWith(JUnit4.class)
-public class LongGaugeTest {
+public class CounterDoubleTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String NAME = "name";
@@ -42,58 +42,58 @@ public class LongGaugeTest {
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
-    LongGauge longGauge =
+    CounterDouble counterDouble =
         metricRegistry
-            .longGaugeBuilder(NAME)
+            .counterDoubleBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
-    longGauge.getOrCreateTimeSeries(null);
+    counterDouble.getOrCreateTimeSeries(null);
   }
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullElement() {
     List<LabelValue> labelValues = Collections.singletonList(null);
-    LongGauge longGauge =
+    CounterDouble counterDouble =
         metricRegistry
-            .longGaugeBuilder(NAME)
+            .counterDoubleBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValue");
-    longGauge.getOrCreateTimeSeries(labelValues);
+    counterDouble.getOrCreateTimeSeries(labelValues);
   }
 
   @Test
   public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
-    LongGauge longGauge =
+    CounterDouble counterDouble =
         metricRegistry
-            .longGaugeBuilder(NAME)
+            .counterDoubleBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    longGauge.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+    counterDouble.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
   }
 
   @Test
   public void noopRemoveTimeSeries_WithNullLabelValues() {
-    LongGauge longGauge =
+    CounterDouble counterDouble =
         metricRegistry
-            .longGaugeBuilder(NAME)
+            .counterDoubleBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
-    longGauge.removeTimeSeries(null);
+    counterDouble.removeTimeSeries(null);
   }
 }

--- a/api/src/test/java/openconsensus/metrics/CounterLongTest.java
+++ b/api/src/test/java/openconsensus/metrics/CounterLongTest.java
@@ -25,9 +25,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link DoubleCumulative}. */
+/** Unit tests for {@link CounterLong}. */
 @RunWith(JUnit4.class)
-public class DoubleCumulativeTest {
+public class CounterLongTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String NAME = "name";
@@ -42,58 +42,58 @@ public class DoubleCumulativeTest {
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
-    DoubleCumulative doubleCumulative =
+    CounterLong counterLong =
         metricRegistry
-            .doubleCumulativeBuilder(NAME)
+            .counterLongBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
-    doubleCumulative.getOrCreateTimeSeries(null);
+    counterLong.getOrCreateTimeSeries(null);
   }
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullElement() {
     List<LabelValue> labelValues = Collections.singletonList(null);
-    DoubleCumulative doubleCumulative =
+    CounterLong counterLong =
         metricRegistry
-            .doubleCumulativeBuilder(NAME)
+            .counterLongBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValue");
-    doubleCumulative.getOrCreateTimeSeries(labelValues);
+    counterLong.getOrCreateTimeSeries(labelValues);
   }
 
   @Test
   public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
-    DoubleCumulative doubleCumulative =
+    CounterLong counterLong =
         metricRegistry
-            .doubleCumulativeBuilder(NAME)
+            .counterLongBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    doubleCumulative.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+    counterLong.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
   }
 
   @Test
   public void noopRemoveTimeSeries_WithNullLabelValues() {
-    DoubleCumulative doubleCumulative =
+    CounterLong counterLong =
         metricRegistry
-            .doubleCumulativeBuilder(NAME)
+            .counterLongBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
-    doubleCumulative.removeTimeSeries(null);
+    counterLong.removeTimeSeries(null);
   }
 }

--- a/api/src/test/java/openconsensus/metrics/GaugeDoubleTest.java
+++ b/api/src/test/java/openconsensus/metrics/GaugeDoubleTest.java
@@ -25,9 +25,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link LongCumulative}. */
+/** Unit tests for {@link GaugeDouble}. */
 @RunWith(JUnit4.class)
-public class LongCumulativeTest {
+public class GaugeDoubleTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String NAME = "name";
@@ -42,58 +42,58 @@ public class LongCumulativeTest {
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
-    LongCumulative longCumulative =
+    GaugeDouble gaugeDouble =
         metricRegistry
-            .longCumulativeBuilder(NAME)
+            .gaugeDoubleBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
-    longCumulative.getOrCreateTimeSeries(null);
+    gaugeDouble.getOrCreateTimeSeries(null);
   }
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullElement() {
     List<LabelValue> labelValues = Collections.singletonList(null);
-    LongCumulative longCumulative =
+    GaugeDouble gaugeDouble =
         metricRegistry
-            .longCumulativeBuilder(NAME)
+            .gaugeDoubleBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValue");
-    longCumulative.getOrCreateTimeSeries(labelValues);
+    gaugeDouble.getOrCreateTimeSeries(labelValues);
   }
 
   @Test
   public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
-    LongCumulative longCumulative =
+    GaugeDouble gaugeDouble =
         metricRegistry
-            .longCumulativeBuilder(NAME)
+            .gaugeDoubleBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    longCumulative.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+    gaugeDouble.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
   }
 
   @Test
   public void noopRemoveTimeSeries_WithNullLabelValues() {
-    LongCumulative longCumulative =
+    GaugeDouble gaugeDouble =
         metricRegistry
-            .longCumulativeBuilder(NAME)
+            .gaugeDoubleBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
-    longCumulative.removeTimeSeries(null);
+    gaugeDouble.removeTimeSeries(null);
   }
 }

--- a/api/src/test/java/openconsensus/metrics/GaugeLongTest.java
+++ b/api/src/test/java/openconsensus/metrics/GaugeLongTest.java
@@ -25,9 +25,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link DoubleGauge}. */
+/** Unit tests for {@link GaugeLong}. */
 @RunWith(JUnit4.class)
-public class DoubleGaugeTest {
+public class GaugeLongTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String NAME = "name";
@@ -42,58 +42,58 @@ public class DoubleGaugeTest {
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
-    DoubleGauge doubleGauge =
+    GaugeLong gaugeLong =
         metricRegistry
-            .doubleGaugeBuilder(NAME)
+            .gaugeLongBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
-    doubleGauge.getOrCreateTimeSeries(null);
+    gaugeLong.getOrCreateTimeSeries(null);
   }
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullElement() {
     List<LabelValue> labelValues = Collections.singletonList(null);
-    DoubleGauge doubleGauge =
+    GaugeLong gaugeLong =
         metricRegistry
-            .doubleGaugeBuilder(NAME)
+            .gaugeLongBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValue");
-    doubleGauge.getOrCreateTimeSeries(labelValues);
+    gaugeLong.getOrCreateTimeSeries(labelValues);
   }
 
   @Test
   public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
-    DoubleGauge doubleGauge =
+    GaugeLong gaugeLong =
         metricRegistry
-            .doubleGaugeBuilder(NAME)
+            .gaugeLongBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Label Keys and Label Values don't have same size.");
-    doubleGauge.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+    gaugeLong.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
   }
 
   @Test
   public void noopRemoveTimeSeries_WithNullLabelValues() {
-    DoubleGauge doubleGauge =
+    GaugeLong gaugeLong =
         metricRegistry
-            .doubleGaugeBuilder(NAME)
+            .gaugeLongBuilder(NAME)
             .setDescription(DESCRIPTION)
             .setLabelKeys(LABEL_KEY)
             .setUnit(UNIT)
             .build();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
-    doubleGauge.removeTimeSeries(null);
+    gaugeLong.removeTimeSeries(null);
   }
 }

--- a/api/src/test/java/openconsensus/metrics/MetricRegistryTest.java
+++ b/api/src/test/java/openconsensus/metrics/MetricRegistryTest.java
@@ -34,27 +34,27 @@ public class MetricRegistryTest {
   public void noopAddLongGauge_NullName() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("name");
-    metricRegistry.longGaugeBuilder(null);
+    metricRegistry.gaugeLongBuilder(null);
   }
 
   @Test
   public void noopAddDoubleGauge_NullName() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("name");
-    metricRegistry.doubleGaugeBuilder(null);
+    metricRegistry.gaugeDoubleBuilder(null);
   }
 
   @Test
   public void noopAddDoubleCumulative_NullName() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("name");
-    metricRegistry.doubleCumulativeBuilder(null);
+    metricRegistry.counterDoubleBuilder(null);
   }
 
   @Test
   public void noopAddLongCumulative_NullName() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("name");
-    metricRegistry.longCumulativeBuilder(null);
+    metricRegistry.counterLongBuilder(null);
   }
 }

--- a/contrib/src/main/java/openconsensus/contrib/metrics/runtime/GarbageCollector.java
+++ b/contrib/src/main/java/openconsensus/contrib/metrics/runtime/GarbageCollector.java
@@ -20,9 +20,9 @@ import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.List;
+import openconsensus.metrics.CounterLong;
 import openconsensus.metrics.LabelKey;
 import openconsensus.metrics.LabelValue;
-import openconsensus.metrics.LongCumulative;
 import openconsensus.metrics.MetricRegistry;
 import openconsensus.metrics.Metrics;
 
@@ -57,9 +57,9 @@ public final class GarbageCollector {
   public void exportAll() {
     // TODO: This should probably be a cumulative Histogram without buckets (or Summary without
     //  percentiles) to allow count/sum.
-    final LongCumulative collectionMetric =
+    final CounterLong collectionMetric =
         metricRegistry
-            .longCumulativeBuilder("collection")
+            .counterLongBuilder("collection")
             .setDescription("Time spent in a given JVM garbage collector in milliseconds.")
             .setUnit("ms")
             .setLabelKeys(Collections.singletonList(GC))

--- a/contrib/src/main/java/openconsensus/contrib/metrics/runtime/MemoryPools.java
+++ b/contrib/src/main/java/openconsensus/contrib/metrics/runtime/MemoryPools.java
@@ -22,9 +22,9 @@ import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
 import java.util.Arrays;
 import java.util.List;
+import openconsensus.metrics.GaugeLong;
 import openconsensus.metrics.LabelKey;
 import openconsensus.metrics.LabelValue;
-import openconsensus.metrics.LongGauge;
 import openconsensus.metrics.MetricRegistry;
 import openconsensus.metrics.Metrics;
 
@@ -73,24 +73,24 @@ public final class MemoryPools {
     //  metrics and avoid using type, but type is nice that you can see what percent of the used
     //  memory is committed (this can also be achieved by displaying the two metrics in the same
     //  chart).
-    final LongGauge areaMetric =
+    final GaugeLong areaMetric =
         this.metricRegistry
-            .longGaugeBuilder("area")
+            .gaugeLongBuilder("area")
             .setDescription("Bytes of a given JVM memory area.")
             .setUnit("By")
             .setLabelKeys(Arrays.asList(TYPE, AREA))
             .build();
-    final LongGauge.TimeSeries usedHeap =
+    final GaugeLong.TimeSeries usedHeap =
         areaMetric.getOrCreateTimeSeries(Arrays.asList(USED, HEAP));
-    final LongGauge.TimeSeries usedNonHeap =
+    final GaugeLong.TimeSeries usedNonHeap =
         areaMetric.getOrCreateTimeSeries(Arrays.asList(USED, NON_HEAP));
-    final LongGauge.TimeSeries committedHeap =
+    final GaugeLong.TimeSeries committedHeap =
         areaMetric.getOrCreateTimeSeries(Arrays.asList(COMMITTED, HEAP));
-    final LongGauge.TimeSeries committedNonHeap =
+    final GaugeLong.TimeSeries committedNonHeap =
         areaMetric.getOrCreateTimeSeries(Arrays.asList(COMMITTED, NON_HEAP));
     // TODO: Decide if max is needed or not. May be derived with some approximation from max(used).
-    final LongGauge.TimeSeries maxHeap = areaMetric.getOrCreateTimeSeries(Arrays.asList(MAX, HEAP));
-    final LongGauge.TimeSeries maxNonHeap =
+    final GaugeLong.TimeSeries maxHeap = areaMetric.getOrCreateTimeSeries(Arrays.asList(MAX, HEAP));
+    final GaugeLong.TimeSeries maxNonHeap =
         areaMetric.getOrCreateTimeSeries(Arrays.asList(MAX, NON_HEAP));
     areaMetric.setCallback(
         new Runnable() {
@@ -110,9 +110,9 @@ public final class MemoryPools {
 
   /** Export only the "pool" metric. */
   public void exportMemoryPoolMetric() {
-    final LongGauge poolMetric =
+    final GaugeLong poolMetric =
         this.metricRegistry
-            .longGaugeBuilder("pool")
+            .gaugeLongBuilder("pool")
             .setDescription("Bytes of a given JVM memory pool.")
             .setUnit("By")
             .setLabelKeys(Arrays.asList(TYPE, POOL))


### PR DESCRIPTION
Change the names to look more how they would have been with templates (if no boxing/unboxing problem): Gauge<Long> -> GaugeLong

OpenMetrics uses Counter as well for this.

Updates https://github.com/bogdandrutu/openconsensus/issues/220 - need to also update the protos to reflect these changes.