### PR TITLE
Do let tags/attributes go through for the OT Shim.

### DIFF
--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
@@ -121,13 +121,11 @@ final class SpanBuilderShim implements SpanBuilder {
           break;
       }
     } else if (Tags.ERROR.getKey().equals(key)) {
-      if (Boolean.parseBoolean(value)) {
-        error = true;
-      }
-    } else {
-      this.spanBuilderAttributeKeys.add(key);
-      this.spanBuilderAttributeValues.add(AttributeValue.stringAttributeValue(value));
+      error = Boolean.parseBoolean(value);
     }
+
+    this.spanBuilderAttributeKeys.add(key);
+    this.spanBuilderAttributeValues.add(AttributeValue.stringAttributeValue(value));
 
     return this;
   }
@@ -135,13 +133,12 @@ final class SpanBuilderShim implements SpanBuilder {
   @Override
   public SpanBuilder withTag(String key, boolean value) {
     if (Tags.ERROR.getKey().equals(key)) {
-      if (value) {
-        error = true;
-      }
-    } else {
-      this.spanBuilderAttributeKeys.add(key);
-      this.spanBuilderAttributeValues.add(AttributeValue.booleanAttributeValue(value));
+      error = value;
     }
+
+    this.spanBuilderAttributeKeys.add(key);
+    this.spanBuilderAttributeValues.add(AttributeValue.booleanAttributeValue(value));
+
     return this;
   }
 

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
@@ -51,22 +51,24 @@ final class SpanShim implements Span {
     if (Tags.SPAN_KIND.getKey().equals(key)) {
       // TODO: confirm we can safely ignore span.kind after Span was created
       // https://github.com/bogdandrutu/openconsensus/issues/42
-    } else if (Tags.ERROR.getKey().equals(key) && Boolean.parseBoolean(value)) {
-      this.span.setStatus(Status.UNKNOWN);
-    } else {
-      span.setAttribute(key, value);
+    } else if (Tags.ERROR.getKey().equals(key)) {
+      Status status = Boolean.parseBoolean(value) ? Status.UNKNOWN : Status.OK;
+      span.setStatus(status);
     }
+
+    span.setAttribute(key, value);
 
     return this;
   }
 
   @Override
   public Span setTag(String key, boolean value) {
-    if (Tags.ERROR.getKey().equals(key) && value) {
-      this.span.setStatus(Status.UNKNOWN);
-    } else {
-      span.setAttribute(key, value);
+    if (Tags.ERROR.getKey().equals(key)) {
+      Status status = value ? Status.UNKNOWN : Status.OK;
+      span.setStatus(status);
     }
+
+    span.setAttribute(key, value);
 
     return this;
   }


### PR DESCRIPTION
I'd like to attributes/tags go through for the OT shim, even if we match them to a new field, i.e. (`span.kind` -> SpanBuilder.setKind()).

The reason for this is that, at this time, backend systems may still depend on these tags/attributes to be set (`error` is an example) - so, by not filtering them out, we are helping them to keep their current codebase working (later they can migrate smoothly by using the new fields).