### PR TITLE
Set status based on error, either true or false.

### DIFF
--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanBuilderShim.java
@@ -121,9 +121,7 @@ final class SpanBuilderShim implements SpanBuilder {
           break;
       }
     } else if (Tags.ERROR.getKey().equals(key)) {
-      if (Boolean.parseBoolean(value)) {
-        error = true;
-      }
+      error = Boolean.parseBoolean(value);
     } else {
       this.spanBuilderAttributeKeys.add(key);
       this.spanBuilderAttributeValues.add(AttributeValue.stringAttributeValue(value));
@@ -135,9 +133,7 @@ final class SpanBuilderShim implements SpanBuilder {
   @Override
   public SpanBuilder withTag(String key, boolean value) {
     if (Tags.ERROR.getKey().equals(key)) {
-      if (value) {
-        error = true;
-      }
+      error = value;
     } else {
       this.spanBuilderAttributeKeys.add(key);
       this.spanBuilderAttributeValues.add(AttributeValue.booleanAttributeValue(value));

--- a/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
+++ b/opentracing-shim/src/main/java/openconsensus/opentracingshim/SpanShim.java
@@ -51,8 +51,9 @@ final class SpanShim implements Span {
     if (Tags.SPAN_KIND.getKey().equals(key)) {
       // TODO: confirm we can safely ignore span.kind after Span was created
       // https://github.com/bogdandrutu/openconsensus/issues/42
-    } else if (Tags.ERROR.getKey().equals(key) && Boolean.parseBoolean(value)) {
-      this.span.setStatus(Status.UNKNOWN);
+    } else if (Tags.ERROR.getKey().equals(key)) {
+      Status status = Boolean.parseBoolean(value) ? Status.UNKNOWN : Status.OK;
+      span.setStatus(status);
     } else {
       span.setAttribute(key, value);
     }
@@ -62,8 +63,9 @@ final class SpanShim implements Span {
 
   @Override
   public Span setTag(String key, boolean value) {
-    if (Tags.ERROR.getKey().equals(key) && value) {
-      this.span.setStatus(Status.UNKNOWN);
+    if (Tags.ERROR.getKey().equals(key)) {
+      Status status = value ? Status.UNKNOWN : Status.OK;
+      span.setStatus(status);
     } else {
       span.setAttribute(key, value);
     }


### PR DESCRIPTION
We currently set `Status.UNKNOWN` in case of the OT's error value is `true`, but we should also set status for `false`.

This is mostly for being on the safe scenario, in case the user re-sets the `error` value.